### PR TITLE
IPI Framework & Ioremap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,8 +28,10 @@ dependencies = [
  "hashbrown",
  "heapless",
  "idalloc",
+ "intrusive-collections",
  "kernel-macros",
  "paste",
+ "range-allocator",
  "rangemap",
  "riscv",
  "sbi-rt",
@@ -406,6 +408,13 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "range-allocator"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "rangemap"

--- a/anemone-abi/build.rs
+++ b/anemone-abi/build.rs
@@ -17,7 +17,7 @@ fn main() {
                         "cargo:warning=Failed to parse source files for cbindgen: {}",
                         error
                     );
-                }
+                },
                 e => panic!("Failed to generate bindings: {:?}", e),
             },
             |bindings| {

--- a/anemone-kernel/Cargo.toml
+++ b/anemone-kernel/Cargo.toml
@@ -16,11 +16,13 @@ paste = { workspace = true }
 yansi = { workspace = true }
 boxcar = { workspace = true }
 rangemap = { workspace = true }
+intrusive-collections = { workspace = true }
 heapless = { workspace = true }
 hashbrown = { workspace = true }
 buddy-system = { path = "crates/buddy-system", features = ["stats"] }
 device-tree = { path = "crates/device-tree", features = ["alloc"] }
 idalloc = { path = "crates/idalloc" }
+range-allocator = { path = "crates/range-allocator" }
 kernel-macros = { path = "crates/kernel-macros" }
 
 

--- a/anemone-kernel/crates/kernel-macros/src/kunit.rs
+++ b/anemone-kernel/crates/kernel-macros/src/kunit.rs
@@ -39,21 +39,30 @@ pub fn kunit_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     if !input.sig.generics.params.is_empty() || input.sig.generics.where_clause.is_some() {
-        return Error::new_spanned(&input.sig.generics, "kunit test function cannot have generics")
-            .to_compile_error()
-            .into();
+        return Error::new_spanned(
+            &input.sig.generics,
+            "kunit test function cannot have generics",
+        )
+        .to_compile_error()
+        .into();
     }
 
     if !input.sig.inputs.is_empty() {
-        return Error::new_spanned(&input.sig.inputs, "kunit test function must have signature fn()")
-            .to_compile_error()
-            .into();
+        return Error::new_spanned(
+            &input.sig.inputs,
+            "kunit test function must have signature fn()",
+        )
+        .to_compile_error()
+        .into();
     }
 
     if input.sig.variadic.is_some() {
-        return Error::new_spanned(&input.sig.variadic, "kunit test function cannot be variadic")
-            .to_compile_error()
-            .into();
+        return Error::new_spanned(
+            &input.sig.variadic,
+            "kunit test function cannot be variadic",
+        )
+        .to_compile_error()
+        .into();
     }
 
     if !matches!(input.sig.output, ReturnType::Default) {

--- a/anemone-kernel/crates/kernel-macros/src/lib.rs
+++ b/anemone-kernel/crates/kernel-macros/src/lib.rs
@@ -21,12 +21,12 @@ pub fn kunit(attr: TokenStream, item: TokenStream) -> TokenStream {
     kunit::kunit_impl(attr, item)
 }
 
-/// Defines an initcall function, which will be called during kernel
-/// initialization.
+/// Defines an initcall.
 ///
-/// The initcall level is specified as an argument, which determines when the
-/// function will be called during initialization. The function must have the
-/// signature `fn()`.
+/// The function must have the signature `fn()`.
+///
+/// Currently supported levels are:
+/// - `driver`
 #[proc_macro_attribute]
 pub fn initcall(attr: TokenStream, item: TokenStream) -> TokenStream {
     initcall::initcall_impl(attr, item)

--- a/anemone-kernel/crates/range-allocator/Cargo.toml
+++ b/anemone-kernel/crates/range-allocator/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "range-allocator"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+hashbrown = { workspace = true }

--- a/anemone-kernel/crates/range-allocator/README.md
+++ b/anemone-kernel/crates/range-allocator/README.md
@@ -1,0 +1,3 @@
+range allocator, with metadata stored outside (i.e. non-intrusive).
+
+Internally implemented with 2 BTreeMaps, one for free ranges and one for allocated ranges. The free range map is keyed by the start address of the range, and the allocated range map is keyed by the end address of the range. This allows for efficient allocation and deallocation of ranges, as well as merging of adjacent free ranges. (O(log n) for allocation and deallocation, O(1) for merging).

--- a/anemone-kernel/crates/range-allocator/src/lib.rs
+++ b/anemone-kernel/crates/range-allocator/src/lib.rs
@@ -1,0 +1,230 @@
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use core::hash::Hash;
+
+use alloc::collections::BTreeMap;
+use hashbrown::HashSet;
+
+pub trait Rangable: Hash + Copy + Eq {
+    fn start(&self) -> usize;
+    fn len(&self) -> usize;
+    fn from_parts(start: usize, length: usize) -> Self;
+}
+
+#[derive(Debug)]
+pub enum RangeAllocError {
+    FreeingExistingRange,
+}
+
+#[derive(Debug)]
+pub struct RangeAllocator<R: Rangable> {
+    free_by_start: BTreeMap<usize, R>,
+    free_by_length: BTreeMap<usize, HashSet<R>>,
+}
+
+impl<R: Rangable> RangeAllocator<R> {
+    pub fn new() -> Self {
+        Self {
+            free_by_start: BTreeMap::new(),
+            free_by_length: BTreeMap::new(),
+        }
+    }
+
+    pub fn allocate(&mut self, length: usize) -> Option<R> {
+        if length == 0 {
+            return None;
+        }
+
+        let (&found_len, ranges) = self.free_by_length.range_mut(length..).next()?;
+        let range = ranges
+            .iter()
+            .next()
+            .expect("Internal error: set of length exist but is empty")
+            .clone();
+        ranges.remove(&range);
+        if ranges.is_empty() {
+            self.free_by_length.remove(&found_len);
+        }
+
+        self.free_by_start
+            .remove(&range.start())
+            .expect("Internal error: free_by_length and free_by_start are out of sync");
+
+        if found_len > length {
+            let allocated = R::from_parts(range.start(), length);
+            let rem = R::from_parts(allocated.start() + length, found_len - length);
+            self.free_by_start.insert(rem.start(), rem);
+            self.free_by_length
+                .entry(rem.len())
+                .or_default()
+                .insert(rem);
+            Some(allocated)
+        } else {
+            Some(range)
+        }
+    }
+
+    pub fn free(&mut self, range: R) -> Result<(), RangeAllocError> {
+        if range.len() == 0 {
+            return Ok(());
+        }
+
+        let mut start = range.start();
+        let mut len = range.len();
+        let end = start + len;
+
+        let prev = self
+            .free_by_start
+            .range(..start)
+            .next_back()
+            .map(|(_, r)| *r);
+        let next = self.free_by_start.range(start..).next().map(|(_, r)| *r);
+
+        if let Some(r) = prev {
+            let r_end = r.start() + r.len();
+            if r_end > start {
+                return Err(RangeAllocError::FreeingExistingRange);
+            } else if r_end == start {
+                start = r.start();
+                len = len + r.len();
+                self.free_by_start.remove(&r.start());
+                let set = self
+                    .free_by_length
+                    .get_mut(&r.len())
+                    .expect("Internal error: free_by_length and free_by_start are out of sync");
+                set.remove(&r);
+                if set.is_empty() {
+                    self.free_by_length.remove(&r.len());
+                }
+            }
+        }
+
+        if let Some(r) = next {
+            if r.start() < end {
+                return Err(RangeAllocError::FreeingExistingRange);
+            } else if r.start() == end {
+                len = len + r.len();
+                self.free_by_start.remove(&r.start());
+                let set = self
+                    .free_by_length
+                    .get_mut(&r.len())
+                    .expect("Internal error: free_by_length and free_by_start are out of sync");
+                set.remove(&r);
+                if set.is_empty() {
+                    self.free_by_length.remove(&r.len());
+                }
+            }
+        }
+
+        let final_range = R::from_parts(start, len);
+        self.free_by_start.insert(start, final_range);
+        self.free_by_length
+            .entry(len)
+            .or_default()
+            .insert(final_range);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    struct TestRange {
+        start: usize,
+        len: usize,
+    }
+
+    impl Rangable for TestRange {
+        fn start(&self) -> usize {
+            self.start
+        }
+
+        fn len(&self) -> usize {
+            self.len
+        }
+
+        fn from_parts(start: usize, length: usize) -> Self {
+            Self { start, len: length }
+        }
+    }
+
+    fn range(start: usize, len: usize) -> TestRange {
+        TestRange { start, len }
+    }
+
+    #[test]
+    fn allocate_zero_returns_none() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+        allocator.free(range(0, 8)).unwrap();
+
+        assert_eq!(allocator.allocate(0), None);
+        assert_eq!(allocator.allocate(8), Some(range(0, 8)));
+    }
+
+    #[test]
+    fn allocate_splits_range_and_preserves_remainder() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+        allocator.free(range(100, 10)).unwrap();
+
+        assert_eq!(allocator.allocate(4), Some(range(100, 4)));
+        assert_eq!(allocator.allocate(6), Some(range(104, 6)));
+        assert_eq!(allocator.allocate(1), None);
+    }
+
+    #[test]
+    fn allocate_prefers_smallest_sufficient_block() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+        allocator.free(range(0, 20)).unwrap();
+        allocator.free(range(100, 8)).unwrap();
+
+        assert_eq!(allocator.allocate(7), Some(range(100, 7)));
+        assert_eq!(allocator.allocate(1), Some(range(107, 1)));
+        assert_eq!(allocator.allocate(20), Some(range(0, 20)));
+        assert_eq!(allocator.allocate(1), None);
+    }
+
+    #[test]
+    fn free_merges_adjacent_ranges_from_both_sides() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+        allocator.free(range(10, 5)).unwrap();
+        allocator.free(range(20, 5)).unwrap();
+        allocator.free(range(15, 5)).unwrap();
+
+        assert_eq!(allocator.allocate(15), Some(range(10, 15)));
+        assert_eq!(allocator.allocate(1), None);
+    }
+
+    #[test]
+    fn free_rejects_overlapping_ranges() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+        allocator.free(range(0, 10)).unwrap();
+
+        assert!(matches!(
+            allocator.free(range(5, 3)),
+            Err(RangeAllocError::FreeingExistingRange)
+        ));
+        assert!(matches!(
+            allocator.free(range(0, 1)),
+            Err(RangeAllocError::FreeingExistingRange)
+        ));
+
+        // Original range should stay intact after rejected frees.
+        assert_eq!(allocator.allocate(10), Some(range(0, 10)));
+        assert_eq!(allocator.allocate(1), None);
+    }
+
+    #[test]
+    fn free_zero_length_is_noop() {
+        let mut allocator = RangeAllocator::<TestRange>::new();
+
+        allocator.free(range(0, 0)).unwrap();
+        allocator.free(range(5, 3)).unwrap();
+
+        assert_eq!(allocator.allocate(3), Some(range(5, 3)));
+        assert_eq!(allocator.allocate(1), None);
+    }
+}

--- a/anemone-kernel/src/arch/link_symbols.rs
+++ b/anemone-kernel/src/arch/link_symbols.rs
@@ -56,10 +56,9 @@ unsafe extern "C" {
     /// The end of the KUnit test data segment of the kernel in virtual memory.
     pub fn __ekunit();
 
-    /// The start of the driver initcall section of the kernel in virtual
-    /// memory.
+    /// The start of the initcall section for driver initcalls.
     pub fn __sinitcall_driver();
-
-    /// The end of the driver initcall section of the kernel in virtual memory.
+    /// The end of the initcall section for driver initcalls.
     pub fn __einitcall_driver();
+
 }

--- a/anemone-kernel/src/arch/mod.rs
+++ b/anemone-kernel/src/arch/mod.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, sync::mono::MonoOnce};
 
 pub mod link_symbols;
 

--- a/anemone-kernel/src/arch/riscv64/bootstrap.rs
+++ b/anemone-kernel/src/arch/riscv64/bootstrap.rs
@@ -5,8 +5,8 @@ use crate::{
     arch::{
         clear_bss,
         riscv64::{
+            exception::on_enter_kernel,
             mm::{RiscV64PgDir, RiscV64Pte, RiscV64PteFlags, sv39},
-            time::set_hw_clock_freq,
         },
     },
     debug::printk::{Console, ConsoleFlags, register_console},
@@ -64,8 +64,8 @@ static BOOTSTRAP_PGDIR: RiscV64PgDir = {
     );
 
     // 3. HHDM optimistic mapping for later use in physical memory management
-    //    initialization. We may map more physical memory than actually exists, but
-    //    it's fine because the kernel will only access the physical memory that
+    //    initialization. We probably map more physical memory than actually exists,
+    //    but it's fine because the kernel will only access the physical memory that
     //    actually exists, and the extra mappings won't cause any harm.
     let s_ram_ppn = align_down_power_of_2!(PHYS_RAM_START, 1 << 30) as u64 >> 12;
     let hhdm_start_idx =
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn __nun() -> ! {
         // Calculate offset for current hart.
         "addi    t2, a0, 1",
 
-        // Without following line, the rustc will emit an error saying 'instruction requires
+        // Without following line, rustc will emit an error saying 'instruction requires
         // the following: 'Zmmul' (Integer Multiplication)',
         // even though we have specified the 'm' extension in the target spec.
         // This is a known issue in rustc, and we take this workaround to make
@@ -215,12 +215,11 @@ fn dump_kernel_image_info() {
 #[unsafe(no_mangle)]
 extern "C" fn rusty_nun(hart_id: usize, fdt_pa: PhysAddr) -> ! {
     #[unsafe(link_section = ".bss.nonzero_init")]
-    static mut BSP_ID: Option<usize> = None;
+    static mut BSP_ARRIVED: bool = false;
     unsafe {
-        let bsp_id = *(&raw const BSP_ID);
-        if bsp_id.is_none() {
+        if !BSP_ARRIVED {
             // bsp
-            BSP_ID = Some(hart_id);
+            BSP_ARRIVED = true;
             bsp_entry(hart_id, fdt_pa);
         } else {
             // ap
@@ -233,26 +232,21 @@ unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
     unsafe {
         clear_bss();
     }
-    let fdt_va = sv39::Sv39KernelLayout::phys_to_hhdm(fdt_pa);
-
     register_earlycon();
 
     kinfoln!("anemone kernel booting...");
     kinfoln!("bsp id: {}", bsp_id);
-    dump_kernel_image_info();
+
+    let fdt_va = sv39::Sv39KernelLayout::phys_to_hhdm(fdt_pa);
 
     unsafe {
-        // time
-        let hw_freq_hz = early_scan_clock_freq(fdt_va);
-        set_hw_clock_freq(hw_freq_hz);
-        kinfoln!(
-            "set_hw_clock_freq: hardware timer frequency set to {} Hz",
-            hw_freq_hz
-        );
+        // needed by percpu initialization.
         let ncpus = early_scan_cpu_count(fdt_va);
         super::cpu::set_ncpus(ncpus);
+        // needed by timer initialization.
+        let freq_hz = early_scan_clock_freq(fdt_va);
+        super::time::set_hw_clock_freq(freq_hz);
 
-        // physical memory management
         let mut scanner = EarlyMemoryScanner::new(fdt_va);
 
         // mark fdt as reserved memory so that it won't be allocated by frame allocator.
@@ -268,26 +262,26 @@ unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
         mm::frame::pmm_init();
         kinfoln!("physical memory management initialized");
 
-        // now it's time to initialize KERNEL_PGDIR
         mm::kpgdir::init_kernel_mapping();
         kinfoln!("kernel mapping initialized");
         mm::kpgdir::activate_kernel_mapping();
         kinfoln!("kernel mapping activated");
 
+        // register drivers to bus types
         driver::init();
 
         unflatten_device_tree(fdt_va);
         of_platform_discovery();
 
-        // TODO: device, drivers, interrupts, etc.
-        // maybe some of these can be deferred to arch-independent initialization
-        // code.
-
-        super::exception::use_ktrap_entry();
+        // set up kernel trap handler
+        on_enter_kernel();
+        riscv::register::sstatus::set_sie();
+        // enable ipi
+        riscv::register::sie::set_ssoft();
 
         // okay, we can wake up APs now.
         {
-            for ap_id in 0..ncpus {
+            for ap_id in 0..CpuArch::ncpus() {
                 if ap_id == bsp_id {
                     continue;
                 }
@@ -302,10 +296,9 @@ unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
                     panic!("failed to start hart {}: {:?}", ap_id, sbiret);
                 }
             }
+            sync_all_cpus();
         }
-        sync_all_cpus();
         kinfoln!("bsp {} running...", bsp_id);
-        //percpu_test();
     }
 
     kernel_main(true)
@@ -327,9 +320,11 @@ unsafe fn sync_all_cpus() {
 
 unsafe fn ap_entry(ap_id: usize) -> ! {
     unsafe {
-        // early console is already registered, so we can use it to print some info.
         kinfoln!("ap {} is starting up...", ap_id);
+        on_enter_kernel();
         mm::percpu::ap_init(ap_id);
+        riscv::register::sstatus::set_sie();
+        riscv::register::sie::set_ssoft();
 
         mm::kpgdir::activate_kernel_mapping();
 

--- a/anemone-kernel/src/arch/riscv64/cpu.rs
+++ b/anemone-kernel/src/arch/riscv64/cpu.rs
@@ -1,10 +1,10 @@
-use crate::prelude::*;
+use crate::{device::discovery::open_firmware::early_scan_cpu_count, prelude::*};
 
 pub struct RiscV64CpuArch;
 
 static mut NCPUS: usize = 0;
 
-pub(super) unsafe fn set_ncpus(ncpus: usize) {
+pub unsafe fn set_ncpus(ncpus: usize) {
     unsafe {
         NCPUS = ncpus;
     }

--- a/anemone-kernel/src/arch/riscv64/exception/intr.rs
+++ b/anemone-kernel/src/arch/riscv64/exception/intr.rs
@@ -42,4 +42,9 @@ impl IntrArchTrait for RiscV64IntrArch {
             }
         }
     }
+
+    fn send_ipi(cpu_id: usize) {
+        let hartmask = sbi_rt::HartMask::from_mask_base(1 << cpu_id, 0);
+        sbi_rt::send_ipi(hartmask).expect("ipi send failed, cannot recover");
+    }
 }

--- a/anemone-kernel/src/arch/riscv64/exception/mod.rs
+++ b/anemone-kernel/src/arch/riscv64/exception/mod.rs
@@ -4,4 +4,4 @@ mod intr;
 pub use intr::RiscV64IntrArch;
 pub use trap::RiscV64TrapArch;
 mod trap;
-pub use trap::use_ktrap_entry;
+pub use trap::on_enter_kernel;

--- a/anemone-kernel/src/arch/riscv64/exception/trap/ktrap.rs
+++ b/anemone-kernel/src/arch/riscv64/exception/trap/ktrap.rs
@@ -1,6 +1,6 @@
 use crate::{
     arch::riscv64::exception::trap::{RiscV64Exception, RiscV64TrapFrame, RiscV64TrapReason},
-    exception::trap::ktrap_handler,
+    exception::trap::{InterruptReason, TrapReason, ktrap_handler},
     prelude::*,
 };
 
@@ -126,7 +126,12 @@ unsafe extern "C" fn rust_ktrap_entry(trapframe: *mut RiscV64TrapFrame) {
 
     unsafe {
         match reason {
-            RiscV64TrapReason::Generic(reason) => ktrap_handler(trapframe, reason),
+            RiscV64TrapReason::Generic(reason) => {
+                if matches!(reason, TrapReason::Interrupt(InterruptReason::Ipi)) {
+                    riscv::register::sip::clear_ssoft();
+                }
+                ktrap_handler(trapframe, reason)
+            },
             RiscV64TrapReason::ArchRecoverable(exception) => {
                 arch_recoverable_handler(trapframe, exception)
             },
@@ -143,7 +148,10 @@ unsafe fn arch_recoverable_handler(trapframe: &mut RiscV64TrapFrame, exception: 
     );
 }
 
-pub unsafe fn use_ktrap_entry() {
+/// Called on the control is transferred to kernel.
+///
+/// Set up trap handler entry point.
+pub fn on_enter_kernel() {
     unsafe {
         unsafe extern "C" {
             fn __ktrap_entry();

--- a/anemone-kernel/src/arch/riscv64/mm/generic.rs
+++ b/anemone-kernel/src/arch/riscv64/mm/generic.rs
@@ -1,7 +1,5 @@
 use core::ops::{Index, IndexMut};
 
-use bitflags::bitflags;
-
 use crate::prelude::*;
 
 pub const PAGE_SIZE_BYTES: usize = 4096;
@@ -130,9 +128,13 @@ impl PteArch for RiscV64Pte {
         PhysPageNum::new(self.get() >> PTE_FLAGS_BITS)
     }
 
-    fn set_flags(&mut self, flags: PteFlags) {
+    unsafe fn set_flags(&mut self, flags: PteFlags) {
         let flags: RiscV64PteFlags = flags.into();
         self.0 = (self.0 & !PTE_FLAGS_MASK) | flags.bits();
+    }
+
+    unsafe fn set_ppn(&mut self, ppn: PhysPageNum) {
+        self.0 = (self.0 & PTE_FLAGS_MASK) | (ppn.get() << PTE_FLAGS_BITS);
     }
 
     fn is_leaf(&self) -> bool {

--- a/anemone-kernel/src/arch/riscv64/mm/sv39.rs
+++ b/anemone-kernel/src/arch/riscv64/mm/sv39.rs
@@ -1,6 +1,10 @@
 use riscv::register::satp;
 
-use crate::{mm::layout::KernelLayoutTrait, prelude::*};
+use crate::{
+    arch::riscv64::mm::{RiscV64PgDir, RiscV64Pte, RiscV64PteFlags},
+    mm::layout::KernelLayoutTrait,
+    prelude::*,
+};
 
 pub struct Sv39PagingArch;
 
@@ -22,6 +26,65 @@ impl PagingArchTrait for Sv39PagingArch {
                 satp_value = in(reg) satp_val,
             )
         }
+    }
+
+    fn prealloc_pgdirs_for_region(pgtbl: &mut PageTable, range: VirtPageRange) {
+        let svpn = range.start();
+        let npages = range.npages() as usize;
+        kdebugln!(
+            "range: [{:#x}, {:#x})",
+            range.start().get(),
+            range.end().get()
+        );
+        debug_assert!(
+            svpn.get()
+                .is_multiple_of(Sv39PagingArch::NPAGES_PER_GB as u64)
+        );
+        debug_assert!(npages.is_multiple_of(Sv39PagingArch::NPAGES_PER_GB));
+
+        // in sv39, a lv.2 pgdir can map 1GB of virtual memory, so we only need
+        // to preallocate lv.2 pgdirs for the given region
+
+        let ngigabytes = npages / Sv39PagingArch::NPAGES_PER_GB;
+
+        let root_kpgdir = unsafe {
+            pgtbl
+                .root_ppn()
+                .to_phys_addr()
+                .to_hhdm()
+                .as_ptr_mut::<RiscV64PgDir>()
+                .as_mut()
+                .expect("pgdir ppn should not be null")
+        };
+
+        // Sv39 root pgdir index is VPN[2], i.e. the highest 9 bits in VPN.
+        let root_idx_base = ((svpn.get()
+            >> ((Sv39PagingArch::PAGE_LEVELS - 1) * Sv39PagingArch::PGDIR_IDX_BITS))
+            & (Sv39PagingArch::PTE_PER_PGDIR as u64 - 1)) as usize;
+
+        for i in 0..ngigabytes {
+            let pgdir_idx = root_idx_base + i;
+
+            let pgdir_ppn = unsafe {
+                alloc_frame_zeroed()
+                    .expect("failed to allocate frame for preallocating page directory")
+                    .leak()
+            };
+
+            unsafe {
+                // a single V bit is enough
+                debug_assert!(root_kpgdir[pgdir_idx].is_empty());
+                root_kpgdir[pgdir_idx] = RiscV64Pte::arch_new(pgdir_ppn, RiscV64PteFlags::VALID);
+            }
+        }
+    }
+
+    fn tlb_shootdown(vaddr: VirtAddr) {
+        riscv::asm::sfence_vma(0, vaddr.get() as usize);
+    }
+
+    fn tlb_shootdown_all() {
+        riscv::asm::sfence_vma_all();
     }
 }
 

--- a/anemone-kernel/src/arch/riscv64/time.rs
+++ b/anemone-kernel/src/arch/riscv64/time.rs
@@ -6,11 +6,7 @@ pub struct RiscV64TimeArch;
 static mut CLOCK_FREQUENCY_HZ: Option<u64> = None;
 
 /// Set the frequency of the timer in hertz.
-///
-/// # Safety
-///
-/// Called by bsp bootstrap code.
-pub(super) unsafe fn set_hw_clock_freq(freq_hz: u64) {
+pub unsafe fn set_hw_clock_freq(freq_hz: u64) {
     unsafe {
         CLOCK_FREQUENCY_HZ = Some(freq_hz);
     }

--- a/anemone-kernel/src/debug/kunit/mod.rs
+++ b/anemone-kernel/src/debug/kunit/mod.rs
@@ -24,10 +24,14 @@ pub fn kunit_runner() {
     let kunits = unsafe {
         use link_symbols::{__ekunit, __skunit};
 
-        let skunit = __skunit as *const () as *const KUnit;
-        let ekunit = __ekunit as *const () as *const KUnit;
-        let count = (ekunit as usize - skunit as usize) / core::mem::size_of::<KUnit>();
-        core::slice::from_raw_parts(skunit, count)
+        let (start, end) = (
+            __skunit as *const () as usize,
+            __ekunit as *const () as usize,
+        );
+        assert!(start.is_multiple_of(align_of::<KUnit>()));
+        assert!((end - start).is_multiple_of(size_of::<KUnit>()));
+        let kunit_count = (end - start) / size_of::<KUnit>();
+        core::slice::from_raw_parts(start as *const KUnit, kunit_count)
     };
 
     kprintln!("{}-- KUnit Test Runner --{}", BOLD, RESET);

--- a/anemone-kernel/src/debug/printk/console.rs
+++ b/anemone-kernel/src/debug/printk/console.rs
@@ -1,8 +1,6 @@
 //! Console abstraction module.
 use core::fmt::Debug;
 
-use bitflags::bitflags;
-
 use crate::prelude::*;
 
 /// A trait for kernel consoles. Implementations of this trait can represent

--- a/anemone-kernel/src/debug/printk/log.rs
+++ b/anemone-kernel/src/debug/printk/log.rs
@@ -86,12 +86,13 @@ impl KernelLog {
         self.buffer.lock_irqsave().push(record);
     }
 
-    /// Gets a snapshot of the current log records in the kernel log buffer.
+    /// Get an weak iterator of the current log records in the kernel log
+    /// buffer.
     ///
     /// TODO: explain the potential inconsistency, which, however, is harmless
     /// for logging purposes.
-    pub fn snapshot(&self) -> Snapshot<'_> {
-        Snapshot {
+    pub fn iter_weak(&self) -> IterWeak<'_> {
+        IterWeak {
             log: self,
             cur_seq: self.buffer.lock_irqsave().oldest_seq(),
         }
@@ -99,12 +100,12 @@ impl KernelLog {
 }
 
 #[derive(Debug)]
-pub struct Snapshot<'a> {
+pub struct IterWeak<'a> {
     log: &'a KernelLog,
     cur_seq: usize,
 }
 
-impl Iterator for Snapshot<'_> {
+impl Iterator for IterWeak<'_> {
     type Item = LogRecord;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/anemone-kernel/src/debug/printk/mod.rs
+++ b/anemone-kernel/src/debug/printk/mod.rs
@@ -15,8 +15,8 @@ static KERNEL_LOG: KernelLog = KernelLog::new();
 /// Registers a console to receive log output with the specified flags.
 pub fn register_console(console: Arc<dyn Console>, flags: ConsoleFlags) {
     if flags.contains(ConsoleFlags::REPLAY) {
-        let snapshot = KERNEL_LOG.snapshot();
-        for record in snapshot {
+        let it = KERNEL_LOG.iter_weak();
+        for record in it {
             let full_msg_str =
                 core::str::from_utf8(&record.msg[..record.len]).unwrap_or("[Invalid UTF-8]");
             console.output(full_msg_str);

--- a/anemone-kernel/src/device/discovery/open_firmware.rs
+++ b/anemone-kernel/src/device/discovery/open_firmware.rs
@@ -225,14 +225,15 @@ mod early {
                     let eppn = PhysPageNum::new(avail_region.end);
 
                     let npages = eppn.get() - sppn.get();
-                    add_mem_zone(MemZone::Avail(AvailMemZone::new(sppn, npages)));
+                    sys_mem_zones().add_mem_zone(MemZone::Avail(AvailMemZone::new(sppn, npages)));
                 }
                 for (rsv_region, rsv_flags) in self.rsv_map.iter() {
                     let sppn = PhysPageNum::new(rsv_region.start);
                     let eppn = PhysPageNum::new(rsv_region.end);
 
                     let npages = eppn.get() - sppn.get();
-                    add_mem_zone(MemZone::Rsv(RsvMemZone::new(sppn, npages, *rsv_flags)));
+                    sys_mem_zones()
+                        .add_mem_zone(MemZone::Rsv(RsvMemZone::new(sppn, npages, *rsv_flags)));
                 }
             }
         }

--- a/anemone-kernel/src/driver/serial/ns16550a.rs
+++ b/anemone-kernel/src/driver/serial/ns16550a.rs
@@ -1,6 +1,7 @@
+//! NS16550A serial port driver for platform bus.
+
 use core::any::Any;
 
-/// NS16550A serial port driver for platform bus.
 use crate::{
     device::{
         bus::platform::{self, PlatformDevice, PlatformDriver},

--- a/anemone-kernel/src/exception/intr/hal.rs
+++ b/anemone-kernel/src/exception/intr/hal.rs
@@ -30,6 +30,15 @@ pub trait IntrArchTrait: Sized {
             Self::restore_local_intr(Self::DISABLED_IRQ_FLAGS);
         }
     }
+
+    /// Send an inter-processor interrupt (IPI) to the specified CPU.
+    ///
+    /// This function is expected not to fail, and should panic immediately if
+    /// the operation cannot be completed successfully.
+    ///
+    /// TODO: some architectures support an integer payload, we shall add that
+    /// in the future if needed.
+    fn send_ipi(cpu_id: usize);
 }
 
 /// Interrupt flags for the current CPU. The exact representation is

--- a/anemone-kernel/src/exception/ipi.rs
+++ b/anemone-kernel/src/exception/ipi.rs
@@ -1,0 +1,107 @@
+//! Inter-processor interrupt handling.
+//!
+//! **Dynamic memory allocation in IPI sendings are prohibited.**
+//!
+//! Currently only synchronous IPIs are supported.
+
+use core::ptr::NonNull;
+
+use intrusive_collections::UnsafeRef;
+
+use crate::prelude::*;
+
+#[derive(Debug, Clone, Copy)]
+pub enum IpiPayload {
+    TlbShootdown { vaddr: Option<VirtAddr> },
+    StopExecution,
+}
+
+#[derive(Debug)]
+struct IpiMsg {
+    payload: IpiPayload,
+    is_accomplished: AtomicBool,
+    link: LinkedListLink,
+}
+
+impl IpiMsg {
+    fn new(payload: IpiPayload) -> IpiMsg {
+        Self {
+            payload,
+            is_accomplished: AtomicBool::new(false),
+            link: LinkedListLink::new(),
+        }
+    }
+}
+
+intrusive_adapter!(
+    IpiMsgAdapter = UnsafeRef<IpiMsg>: IpiMsg { link => LinkedListLink }
+);
+
+#[percpu]
+static IPI_QUEUE: SpinLock<LinkedList<IpiMsgAdapter>> =
+    SpinLock::new(LinkedList::new(IpiMsgAdapter::NEW));
+
+/// Send an IPI to the target CPU.
+pub fn send_ipi(cpu_id: usize, payload: IpiPayload, asynk: bool) {
+    if asynk {
+        unimplemented!("asynchronous IPIs are not supported yet.");
+    } else {
+        let msg = IpiMsg::new(payload);
+        let msg_ptr = unsafe { UnsafeRef::from_raw(&msg) };
+        unsafe {
+            IPI_QUEUE.with_remote(cpu_id, |queue| {
+                let mut queue = queue.lock_irqsave();
+                queue.push_back(msg_ptr);
+            })
+        }
+        IntrArch::send_ipi(cpu_id);
+        loop {
+            if msg.is_accomplished.load(Ordering::Acquire) {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+    }
+}
+
+/// Broadcast an IPI to all other CPUs.
+pub fn broadcast_ipi(payload: IpiPayload, asynk: bool) {
+    let cur_cpuid = CpuArch::cur_cpu_id();
+    let ncpus = CpuArch::ncpus();
+    for id in 0..ncpus {
+        if id != cur_cpuid {
+            send_ipi(id, payload, asynk);
+        }
+    }
+}
+
+/// IPI handler.
+pub fn handle_ipi() {
+    use IpiPayload::*;
+
+    IPI_QUEUE.with(|queue| {
+        loop {
+            let Some(msg_ptr) = queue.lock_irqsave().pop_front() else {
+                break;
+            };
+            let msg = unsafe { msg_ptr.as_ref() };
+            kdebugln!("handle ipi: payload={:?}", msg.payload);
+            match msg.payload {
+                TlbShootdown { vaddr } => {
+                    if let Some(vaddr) = vaddr {
+                        PagingArch::tlb_shootdown(vaddr);
+                    } else {
+                        PagingArch::tlb_shootdown_all();
+                    }
+                    msg.is_accomplished.store(true, Ordering::Release);
+                },
+                StopExecution => {
+                    msg.is_accomplished.store(true, Ordering::Release);
+                    loop {
+                        core::hint::spin_loop();
+                    }
+                },
+            }
+        }
+    })
+}

--- a/anemone-kernel/src/exception/mod.rs
+++ b/anemone-kernel/src/exception/mod.rs
@@ -9,6 +9,8 @@ mod preempt_counter;
 pub use preempt_counter::PreemptCounter;
 mod page_fault;
 pub use page_fault::{PageFaultInfo, PageFaultType};
+mod ipi;
+pub use ipi::{IpiPayload, broadcast_ipi, send_ipi};
 
 pub mod intr;
 pub mod trap;

--- a/anemone-kernel/src/exception/trap/ktrap.rs
+++ b/anemone-kernel/src/exception/trap/ktrap.rs
@@ -1,7 +1,13 @@
 //! From-kernel trap handling.
 
 use crate::{
-    exception::trap::hal::{ExceptionReason, TrapArchTrait, TrapReason},
+    exception::{
+        ipi::handle_ipi,
+        trap::{
+            InterruptReason,
+            hal::{ExceptionReason, TrapArchTrait, TrapReason},
+        },
+    },
     prelude::*,
 };
 
@@ -37,6 +43,11 @@ pub unsafe fn ktrap_handler(
                 panic!("fatal architecture-specific exception in kernel");
             },
         },
-        TrapReason::Interrupt(interrupt) => todo!(),
+        TrapReason::Interrupt(interrupt) => match interrupt {
+            InterruptReason::Ipi => {
+                handle_ipi();
+            },
+            _ => unimplemented!(),
+        },
     }
 }

--- a/anemone-kernel/src/main.rs
+++ b/anemone-kernel/src/main.rs
@@ -30,9 +30,9 @@ pub mod syserror;
 pub mod time;
 pub mod utils;
 
-use crate::prelude::*;
+use crate::{prelude::*, sync::mono::MonoOnce};
 
-pub fn kernel_main(is_bsp: bool) -> ! {
+fn kernel_main(is_bsp: bool) -> ! {
     // TODO: init subsystems, spawn init process, etc.
 
     if is_bsp {

--- a/anemone-kernel/src/mm/addr.rs
+++ b/anemone-kernel/src/mm/addr.rs
@@ -1,11 +1,10 @@
 //! Strongly-typed wrappers around addresses.
 
+use crate::{int_like, mm::layout::KernelLayoutTrait, prelude::*};
 use core::{
     fmt::Display,
     ops::{Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, Not, Sub, SubAssign},
 };
-
-use crate::{int_like, mm::layout::KernelLayoutTrait, prelude::*};
 
 int_like!(PhysAddr, u64);
 int_like!(VirtAddr, u64);
@@ -142,7 +141,7 @@ impl VirtPageNum {
 
 macro_rules! impl_page_range {
     ($name:ident, $pn_type:ty) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub struct $name {
             start: $pn_type,
             npages: u64,
@@ -171,8 +170,12 @@ macro_rules! impl_page_range {
                 self.npages
             }
 
-            pub fn contains(&self, pn: $pn_type) -> bool {
-                self.start <= pn && pn < self.end()
+            pub const fn contains(&self, pn: $pn_type) -> bool {
+                self.start.get() <= pn.get() && pn.get() < self.start.get() + self.npages
+            }
+
+            pub const fn intersects(&self, other: &Self) -> bool {
+                self.start.get() < other.end().get() && other.start.get() < self.end().get()
             }
 
             paste::paste! {

--- a/anemone-kernel/src/mm/error.rs
+++ b/anemone-kernel/src/mm/error.rs
@@ -11,6 +11,9 @@ pub enum MmError {
     AlreadyMapped,
     /// The virtual address is not mapped.
     NotMapped,
+    /// General invalid argument, e.g. an free operation with an invalid address
+    /// or length.
+    InvalidArgument,
 }
 
 impl AsErrno for MmError {

--- a/anemone-kernel/src/mm/frame/mod.rs
+++ b/anemone-kernel/src/mm/frame/mod.rs
@@ -1,6 +1,5 @@
 // Physical frame management.
 
-use bitflags::bitflags;
 use spin::Lazy;
 
 use crate::{
@@ -12,112 +11,6 @@ pub(super) mod allocator;
 mod buddy;
 mod managed;
 pub use managed::*;
-
-#[derive(Debug, Clone, Copy)]
-pub struct AvailMemZone {
-    start_ppn: PhysPageNum,
-    npages: u64,
-}
-
-impl AvailMemZone {
-    pub fn new(start_ppn: PhysPageNum, npages: u64) -> Self {
-        Self { start_ppn, npages }
-    }
-
-    pub fn range(&self) -> PhysPageRange {
-        PhysPageRange::new(self.start_ppn, self.npages)
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct RsvMemFlags: u32 {
-        /// Memory that should not be mapped by the kernel's paging
-        /// subsystem.
-        const NOMAP = 0x0001;
-
-        /// Memory that can be reused by kernel.
-        const REUSABLE = 0x0002;
-
-        /// Kernel image region.
-        const KVIRT = 0x0004;
-
-        /// Memory that can be used for early allocation before
-        /// the frame allocator is initialized.
-        const EARLY_ALLOC = 0x0008;
-
-        /// Memory reserved for the Flattened Device Tree blob.
-        ///
-        /// TODO: This flag is in theory needless. We should use a RECLAIMABLE flag instead.
-        const FDT = 0x0010;
-    }
-}
-
-impl RsvMemFlags {
-    pub fn is_mappable(&self) -> bool {
-        !self.contains(RsvMemFlags::NOMAP)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct RsvMemZone {
-    start_ppn: PhysPageNum,
-    npages: u64,
-    flags: RsvMemFlags,
-}
-
-impl RsvMemZone {
-    pub fn new(start_ppn: PhysPageNum, npages: u64, flags: RsvMemFlags) -> Self {
-        Self {
-            start_ppn,
-            npages,
-            flags,
-        }
-    }
-
-    pub fn range(&self) -> PhysPageRange {
-        PhysPageRange::new(self.start_ppn, self.npages)
-    }
-
-    pub fn flags(&self) -> RsvMemFlags {
-        self.flags
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum MemZone {
-    Avail(AvailMemZone),
-    Rsv(RsvMemZone),
-}
-
-// TODO: switch to a more appropriate synchronization primitive.
-// currently SpinLock is used for simplicity.
-
-// LOCK ORDERING: MEM_ZONES -> AVAIL_MEM_ZONES -> RSV_MEM_ZONES
-
-pub static MEM_ZONES: Lazy<SpinLock<Vec<MemZone>>> = Lazy::new(|| SpinLock::new(Vec::new()));
-pub static AVAIL_MEM_ZONES: Lazy<SpinLock<Vec<AvailMemZone>>> =
-    Lazy::new(|| SpinLock::new(Vec::new()));
-pub static RSV_MEM_ZONES: Lazy<SpinLock<Vec<RsvMemZone>>> = Lazy::new(|| SpinLock::new(Vec::new()));
-
-/// Adds a memory zone to the physical memory manager.
-///
-/// # Safety
-/// The caller must ensure that the memory zone specified by `zone` is valid
-/// and **does not overlap** with any existing memory zones. The
-/// behavior is undefined if the caller violates this requirement.
-pub unsafe fn add_mem_zone(zone: MemZone) {
-    let mut mem_zones = MEM_ZONES.lock_irqsave();
-    let mut avail_mem_zones = AVAIL_MEM_ZONES.lock_irqsave();
-    let mut rsv_mem_zones = RSV_MEM_ZONES.lock_irqsave();
-
-    kinfoln!("add_mem_zone: adding memory zone: {:x?}", zone);
-    mem_zones.push(zone);
-    match zone {
-        MemZone::Avail(avail_zone) => avail_mem_zones.push(avail_zone),
-        MemZone::Rsv(rsv_zone) => rsv_mem_zones.push(rsv_zone),
-    }
-}
 
 static FRAME_ALLOCATOR: Lazy<LockedFrameAllocator<BuddyAllocator>> =
     Lazy::new(|| LockedFrameAllocator::new(BuddyAllocator::new()));
@@ -131,44 +24,40 @@ static FRAME_ALLOCATOR: Lazy<LockedFrameAllocator<BuddyAllocator>> =
 /// undefined if this function is called multiple times or if it is called
 /// before all memory zones have been added.
 pub unsafe fn pmm_init() {
-    let avail_mem_zones = AVAIL_MEM_ZONES.lock_irqsave();
-    for zone in avail_mem_zones.iter() {
-        let range = PhysPageRange::new(zone.start_ppn, zone.npages);
-        unsafe {
-            FRAME_ALLOCATOR.add_range(range);
+    sys_mem_zones().with_avail_zones(|avail_zones| {
+        for zone in avail_zones.iter() {
+            let range = zone.range();
+            unsafe {
+                FRAME_ALLOCATOR.add_range(range);
+            }
         }
-    }
+    });
 }
 
 pub fn frame_allocator_stats() -> allocator::FrameAllocatorStats {
     FRAME_ALLOCATOR.stats()
 }
 
-mod alloc {
-    use super::*;
-
-    /// Allocates a contiguous range of physical pages.
-    pub fn alloc_frames(npages: usize) -> Option<Folio> {
-        FRAME_ALLOCATOR.alloc(npages)
-    }
-
-    /// Allocates a single physical page.
-    pub fn alloc_frame() -> Option<Frame> {
-        FRAME_ALLOCATOR.alloc_one()
-    }
-
-    /// Allocates a contiguous range of physical pages and zeroes them.
-    pub fn alloc_frames_zeroed(npages: usize) -> Option<Folio> {
-        let mut folio = alloc_frames(npages)?;
-        folio.as_bytes_mut().fill(0);
-        Some(folio)
-    }
-
-    /// Allocates a single physical page and zeroes it.
-    pub fn alloc_frame_zeroed() -> Option<Frame> {
-        let mut frame = alloc_frame()?;
-        frame.as_bytes_mut().fill(0);
-        Some(frame)
-    }
+/// Allocates a contiguous range of physical pages.
+pub fn alloc_frames(npages: usize) -> Option<Folio> {
+    FRAME_ALLOCATOR.alloc(npages)
 }
-pub use alloc::*;
+
+/// Allocates a single physical page.
+pub fn alloc_frame() -> Option<Frame> {
+    FRAME_ALLOCATOR.alloc_one()
+}
+
+/// Allocates a contiguous range of physical pages and zeroes them.
+pub fn alloc_frames_zeroed(npages: usize) -> Option<Folio> {
+    let mut folio = alloc_frames(npages)?;
+    folio.as_bytes_mut().fill(0);
+    Some(folio)
+}
+
+/// Allocates a single physical page and zeroes it.
+pub fn alloc_frame_zeroed() -> Option<Frame> {
+    let mut frame = alloc_frame()?;
+    frame.as_bytes_mut().fill(0);
+    Some(frame)
+}

--- a/anemone-kernel/src/mm/kpgdir.rs
+++ b/anemone-kernel/src/mm/kpgdir.rs
@@ -10,7 +10,7 @@
 
 use spin::Lazy;
 
-use crate::prelude::*;
+use crate::{exception::broadcast_ipi, mm::layout::KernelLayoutTrait, prelude::*};
 
 static KERNEL_PGDIR: KPgDir = KPgDir::new();
 
@@ -18,7 +18,7 @@ static KERNEL_PGDIR: KPgDir = KPgDir::new();
 /// for mapping kernel memory regions, and serves as a marker type for the
 /// kernel's root page directory.
 #[derive(Debug)]
-pub struct KPgDir {
+struct KPgDir {
     pgdir: Lazy<SpinLock<PageTable>>,
 }
 
@@ -55,13 +55,14 @@ impl KPgDir {
                         PagingArch::PAGE_SIZE_BYTES) / PagingArch::PAGE_SIZE_BYTES) as u64
                     );
 
-                    mapper.map(Mapping {
-                        vpn: svpn,
-                        ppn: sppn,
-                        flags: $flags,
-                        npages: npages as usize,
-                        overwrite: false,
-                    }).expect(concat!("failed to map kernel ", stringify!($name), " segment"));
+                    unsafe {
+                        mapper.map_overwrite(Mapping {
+                            vpn: svpn,
+                            ppn: sppn,
+                            flags: $flags,
+                            npages: npages as usize,
+                        }).expect(concat!("failed to map kernel ", stringify!($name), " segment"));
+                    }
                 }
             }};
         }
@@ -80,20 +81,20 @@ impl KPgDir {
         // currently we use normal page mapping for hhdm region, which is tooooooo
         // slow...
         {
-            let avail_mem_zones = AVAIL_MEM_ZONES.lock_irqsave();
+            sys_mem_zones().with_avail_zones(|avail_mem_zones| {
             for zone in avail_mem_zones.iter() {
                 let range = zone.range();
 
+                unsafe {
                 mapper
-                    .map(Mapping {
+                    .map_overwrite(Mapping {
                         vpn: range.start().to_hhdm(),
                         ppn: range.start(),
                         flags: PteFlags::READ | PteFlags::WRITE,
                         npages: range.npages() as usize,
-                        overwrite: false,
                     })
                     .expect("failed to map direct mapping region");
-
+                }
                 kdebugln!(
                     "mapped direct mapping region:\n\tvirtual page number {} ~ {},\n\tphysical page number {} ~ {},\n\tflags = {:?}",
                     range.start().to_hhdm(),
@@ -103,27 +104,27 @@ impl KPgDir {
                     PteFlags::READ | PteFlags::WRITE,
                 );
             }
+        });
         }
 
         // reserved memory regions
         {
-            let rsv_mem_zones = RSV_MEM_ZONES.lock_irqsave();
-            for zone in rsv_mem_zones.iter() {
-                if zone.flags().is_mappable() {
-                    let range = zone.range();
+            sys_mem_zones().with_rsv_zones(|rsv_mem_zones| {
+                for zone in rsv_mem_zones.iter() {
+                    if zone.flags().is_mappable() {
+                        let range = zone.range();
 
-                    mapper
-                        .map(Mapping {
-                            vpn: range.start().to_hhdm(),
-                            ppn: range.start(),
-                            // TODO: for kvirt region, we may want to map with more fine-grained
-                            // permissions.
-                            flags: PteFlags::READ | PteFlags::WRITE,
-                            npages: range.npages() as usize,
-                            overwrite: false,
-                        })
-                        .expect("failed to map reserved memory region");
-
+                    unsafe {
+                        mapper
+                            .map_overwrite(Mapping {
+                                vpn: range.start().to_hhdm(),
+                                ppn: range.start(),
+                                // TODO: for kvirt region, we may want to map with more fine-grained
+                                // permissions.
+                                flags: PteFlags::READ | PteFlags::WRITE,
+                                npages: range.npages() as usize,
+                            }).expect("failed to map reserved memory region");
+                    }
                     kdebugln!(
                         "mapped reserved memory region to hhdm:\n\tvirtual page number {} ~ {},\n\tphysical page number {} ~ {},\n\tflags = {:?}",
                         range.start().to_hhdm(),
@@ -133,8 +134,33 @@ impl KPgDir {
                         zone.flags(),
                     );
                 }
-            }
+            }});
         }
+    }
+
+    unsafe fn init_virtual_ranges(&self) {
+        let mut kpgdir = self.pgdir.lock_irqsave();
+
+        unsafe {
+            kinfoln!(
+                "preallocate pgdirs for remap region: [{:#x}, {:#x})",
+                KernelLayout::REMAP_REGION.start().get(),
+                KernelLayout::REMAP_REGION.end().get()
+            );
+            PagingArch::prealloc_pgdirs_for_region(&mut kpgdir, KernelLayout::REMAP_REGION);
+        }
+    }
+
+    unsafe fn kmap(&self, mapping: Mapping) -> Result<(), MmError> {
+        let mut kpgdir = self.pgdir.lock_irqsave();
+        let mut mapper = kpgdir.mapper();
+        mapper.map(mapping)
+    }
+
+    unsafe fn kunmap(&self, unmapping: Unmapping) {
+        let mut kpgdir = self.pgdir.lock_irqsave();
+        let mut mapper = kpgdir.mapper();
+        mapper.unmap(unmapping);
     }
 }
 
@@ -142,22 +168,53 @@ impl KPgDir {
 /// regions to the kernel's root page directory, including:
 /// - HHDM region / direct mapping region
 /// - kernel image region / kvirt region
-/// - TODO: vmalloc region, vmemmap region, etc.
+/// - vmalloc region
 ///
-/// Note that, after this function is called, all pgdirs will not be changed at
-/// runtime, only leaf mappings might be changed. So we can safely share the
-/// same pgdir for all processes. (IPI shooting and TLB shootdowns are still
-/// needed when leaf mappings are changed, but that's a different story.)
-pub unsafe fn init_kernel_mapping() {
+/// Note that, after this function is called, all top-level pgdirs will not be
+/// changed at runtime, So we can safely share the same pgdir for all processes.
+/// (TLB shootdowns are still needed when leaf mappings are changed, but that's
+/// a different story.)
+pub fn init_kernel_mapping() {
     unsafe {
         KERNEL_PGDIR.map_kvirt();
         KERNEL_PGDIR.map_hhdm();
+        KERNEL_PGDIR.init_virtual_ranges();
     }
 }
 
+/// Switch to kernel mapping.
 pub unsafe fn activate_kernel_mapping() {
     unsafe {
         let kpgdir = KERNEL_PGDIR.pgdir.lock_irqsave();
         PagingArch::activate_addr_space(&kpgdir);
     }
+}
+
+/// Do a mapping in the global kernel page table.
+///
+/// This is always a non-overwrite mapping, thus the operation itself is
+/// safe.
+///
+/// However, this mapping occurs in the global kernel page table, which is
+/// shared by all processes, so it might cause many many potential issues if
+/// not used carefully. So we mark this function as unsafe.
+pub unsafe fn kmap(mapping: Mapping) -> Result<(), MmError> {
+    unsafe {
+        KERNEL_PGDIR.kmap(mapping)?;
+    }
+    broadcast_ipi(IpiPayload::TlbShootdown { vaddr: None }, false);
+    Ok(())
+}
+
+/// Do an unmapping in the global kernel page table. See [kmap] for details and
+/// safety concerns.
+///
+/// Though an unmapping always succeeds, this function should not be overused,
+/// as it will cause TLB shootdowns to all cores, which is very expensive. So we
+/// mark this function as unsafe.
+pub unsafe fn kunmap(unmapping: Unmapping) {
+    unsafe {
+        KERNEL_PGDIR.kunmap(unmapping);
+    }
+    broadcast_ipi(IpiPayload::TlbShootdown { vaddr: None }, false);
 }

--- a/anemone-kernel/src/mm/layout.rs
+++ b/anemone-kernel/src/mm/layout.rs
@@ -17,7 +17,11 @@ pub trait KernelLayoutTrait<P: PagingArchTrait> {
 
     /// The offset between the physical address and the virtual address in the
     /// direct mapping region.
-    const DIRECT_MAPPING_OFFSET: usize = Self::DIRECT_MAPPING_ADDR as usize - 0;
+    const DIRECT_MAPPING_OFFSET: usize = const {
+        let ret = Self::DIRECT_MAPPING_ADDR as usize - 0;
+        assert!(ret.is_multiple_of(P::PAGE_SIZE_BYTES));
+        ret
+    };
 
     /// The starting virtual address of the kernel mapping region, i.e., the
     /// region where the kernel is mapped to virtual memory.
@@ -30,6 +34,17 @@ pub trait KernelLayoutTrait<P: PagingArchTrait> {
     /// The offset between the physical address and the virtual address in the
     /// kernel mapping region.
     const KERNEL_MAPPING_OFFSET: usize = (Self::KERNEL_VA_BASE - Self::KERNEL_LA_BASE) as usize;
+
+    // starting from (Self::DIRECT_MAPPING_ADDR + MAX_PHYS_MEM_SIZE), Anemone
+    // defines various virtual memory regions for management.
+
+    /// vmalloc and ioremap region.
+    const REMAP_REGION: VirtPageRange = VirtPageRange::new(
+        VirtPageNum::new(
+            (Self::DIRECT_MAPPING_ADDR + PHYS_RAM_START + MAX_PHYS_RAM_SIZE) >> P::PAGE_SIZE_BITS,
+        ),
+        P::NPAGES_PER_GB as u64 * (1 << REMAP_SHIFT_GB),
+    );
 
     /// Convert a physical address to a virtual address in the direct mapping
     /// region.

--- a/anemone-kernel/src/mm/mod.rs
+++ b/anemone-kernel/src/mm/mod.rs
@@ -7,5 +7,7 @@ pub mod kpgdir;
 pub mod layout;
 pub mod paging;
 pub mod percpu;
+pub mod remap;
+pub mod zone;
 
 pub mod error;

--- a/anemone-kernel/src/mm/paging/hal.rs
+++ b/anemone-kernel/src/mm/paging/hal.rs
@@ -1,7 +1,5 @@
 use core::ops::{Index, IndexMut};
 
-use bitflags::bitflags;
-
 use crate::prelude::*;
 
 /// The architecture-specific traits and types for paging.
@@ -12,6 +10,12 @@ pub trait PagingArchTrait: Sized {
     /// The number of bits in the page offset, i.e., the number of bits needed
     /// to represent the page size.
     const PAGE_SIZE_BITS: usize = Self::PAGE_SIZE_BYTES.trailing_zeros() as usize;
+
+    /// The number of pages per megabyte.
+    const NPAGES_PER_MB: usize = 1024 * 1024 / Self::PAGE_SIZE_BYTES;
+    /// The number of pages per gigabyte.
+    const NPAGES_PER_GB: usize = 1024 * 1024 * 1024 / Self::PAGE_SIZE_BYTES;
+
     /// The number of levels in the page table hierarchy.
     const PAGE_LEVELS: usize;
 
@@ -48,6 +52,34 @@ pub trait PagingArchTrait: Sized {
     ///
     /// This function should always do a TLB shootdown.
     unsafe fn activate_addr_space(pgtbl: &PageTable);
+
+    /// Preallocate page directories for the given virtual address range.
+    ///
+    /// This function is currently used for vmalloc, fixmap, vmemmap and other
+    /// similar virtual memory regions.
+    ///
+    /// **The range is guaranteed to be aligned to GB.**
+    ///
+    /// This function is expected to panic immediately on failure, since kernel
+    /// cannot function properly without the necessary page directories
+    /// for those regions.
+    ///
+    /// TODO: This is a temporary workaround for the lack of sufficiently
+    /// flexible page table management and support for huge page mapping. We
+    /// should eventually implement those features and remove this function.
+    fn prealloc_pgdirs_for_region(pgtbl: &mut PageTable, range: VirtPageRange);
+
+    /// Perform a TLB shootdown for the given virtual address in all virtual
+    /// address spaces on current core.
+    ///
+    /// TODO: extend this to support ASID/PCID-based shootdowns.
+    fn tlb_shootdown(vaddr: VirtAddr);
+
+    /// Perform a TLB shootdown for the whole address space, in all virtual
+    /// address spaces on current core.
+    ///
+    /// TODO: extend this to support ASID/PCID-based shootdowns.
+    fn tlb_shootdown_all();
 }
 
 bitflags! {
@@ -108,10 +140,24 @@ pub trait PteArch: Sized + From<u64> + Into<u64> + Copy {
         self.is_valid() && !self.is_leaf()
     }
 
-    /// Set the flags of this page table entry to the given flags.
+    /// Set the flags of this page table entry to the given flags, while keeping
+    /// the physical page number unchanged.
     ///
-    /// This function should not modify the physical page number of the entry.
-    fn set_flags(&mut self, flags: PteFlags);
+    /// # Safety
+    ///
+    /// In most cases, a TLB shootdown should be performed after this operation.
+    unsafe fn set_flags(&mut self, flags: PteFlags);
+
+    /// Set the physical page number of this page table entry to the given
+    /// physical page number, while keeping the flags unchanged.
+    ///
+    /// # Safety
+    ///
+    /// In most cases, a TLB shootdown should be performed after this operation.
+    unsafe fn set_ppn(&mut self, ppn: PhysPageNum) {
+        let flags = self.flags();
+        *self = Self::new(ppn, flags);
+    }
 }
 pub trait PgDirArch:
     Sized + Copy + Index<usize, Output = Self::Pte> + IndexMut<usize, Output = Self::Pte>

--- a/anemone-kernel/src/mm/paging/mapper.rs
+++ b/anemone-kernel/src/mm/paging/mapper.rs
@@ -2,19 +2,13 @@ use core::marker::PhantomData;
 
 use crate::prelude::*;
 
-/// A mapping operation.
+/// POD struct representing a mapping operation.
 #[derive(Debug, Clone, Copy)]
 pub struct Mapping {
     pub vpn: VirtPageNum,
     pub ppn: PhysPageNum,
     pub flags: PteFlags,
     pub npages: usize,
-
-    /// Whether to overwrite the existing mapping if the virtual address is
-    /// already mapped. If false, the mapping will fail with an error if the
-    /// virtual address is already mapped. If true, the existing mapping will be
-    /// replaced with the new mapping.
-    pub overwrite: bool,
 }
 
 /// An unmapping operation.
@@ -65,34 +59,115 @@ impl Mapper<'_> {
     }
 
     /// Map a virtual memory region to a physical memory region with the given
-    /// flags.
+    /// flags. Had encountered an already mapped page will cause an error to be
+    /// returned, and all the successfully mapped pages will be rolled back.
     ///
     /// No huge page mapping is involved.
     pub fn map(&mut self, mapping: Mapping) -> Result<(), MmError> {
+        #[derive(Debug)]
+        struct MapTransaction<'a, 'm> {
+            mapper: &'a mut Mapper<'m>,
+            mapping: Mapping,
+            mapped_pages: usize,
+            is_committed: bool,
+        }
+
+        impl<'a, 'm> MapTransaction<'a, 'm> {
+            fn new(mapper: &'a mut Mapper<'m>, mapping: Mapping) -> Self {
+                Self {
+                    mapper,
+                    mapping,
+                    mapped_pages: 0,
+                    is_committed: false,
+                }
+            }
+
+            fn do_map(&mut self) -> Result<(), MmError> {
+                let Mapping {
+                    vpn,
+                    ppn,
+                    flags,
+                    npages,
+                } = self.mapping;
+
+                for i in 0..npages {
+                    let next_vpn = VirtPageNum::new(vpn.get() + i as u64);
+                    let next_ppn = PhysPageNum::new(ppn.get() + i as u64);
+                    self.mapper.map_one(next_vpn, next_ppn, flags, false)?;
+                    self.mapped_pages += 1;
+                }
+
+                Ok(())
+            }
+
+            fn commit(mut self) {
+                self.is_committed = true;
+            }
+        }
+
+        impl Drop for MapTransaction<'_, '_> {
+            fn drop(&mut self) {
+                if !self.is_committed {
+                    knoticeln!(
+                        "MapTransaction::Drop: transaction failed, rolling back the mapped pages"
+                    );
+                    // roll back the mapping of already mapped pages
+                    self.mapper.unmap(Unmapping {
+                        range: VirtPageRange::new(self.mapping.vpn, self.mapped_pages as u64),
+                    });
+                }
+            }
+        }
+
+        let mut transaction = MapTransaction::new(self, mapping);
+        transaction.do_map()?;
+        transaction.commit();
+
+        Ok(())
+    }
+
+    /// Map a virtual memory region to a physical memory region with the given
+    /// flags, even if some of the pages in the region are already mapped.
+    ///
+    /// # Safety
+    ///
+    /// **No atomicity guarantees**
+    ///
+    /// Unless user can ensure success of the operation, it is
+    /// always recommended to first unmap the virtual address and then map
+    /// it again, instead of using overwrite mapping directly.
+    pub unsafe fn map_overwrite(&mut self, mapping: Mapping) -> Result<(), MmError> {
         let Mapping {
             vpn,
             ppn,
             flags,
             npages,
-
-            overwrite,
+            ..
         } = mapping;
         for i in 0..npages {
-            self.map_one(
-                VirtPageNum::new(vpn.get() + i as u64),
-                PhysPageNum::new(ppn.get() + i as u64),
-                flags,
-                overwrite,
-            )?;
+            let next_vpn = VirtPageNum::new(vpn.get() + i as u64);
+            let next_ppn = PhysPageNum::new(ppn.get() + i as u64);
+            self.map_one(next_vpn, next_ppn, flags, true).map_err(|err| {
+                kwarningln!(
+                    "Mapper::map_overwrite: failed to map vpn {:?} to ppn {:?} with flags {:?}: {:?}",
+                    next_vpn,
+                    next_ppn,
+                    flags,
+                    err
+                );
+                err
+            })?;
         }
+
         Ok(())
     }
 
-    /// Unmap a virtual memory region.
+    /// Unmap a virtual memory region and deallocate page tables if they become
+    /// empty after unmapping.
     ///
-    /// This method will deallocate page tables if they become empty after
-    /// unmapping.
-    pub fn unmap(&mut self, unmapping: Unmapping) -> Result<(), MmError> {
+    /// **This method is deliberately designed not to return a [Result] but
+    /// always succeed.**
+    pub fn unmap(&mut self, unmapping: Unmapping) {
         let Unmapping { range } = unmapping;
 
         unsafe {
@@ -112,10 +187,16 @@ impl Mapper<'_> {
                         *pte = Pte::ZEROED;
                         let _frame = Frame::from_ppn(ppn);
                     }
-                    ControlFlow::Continue
+                    ControlFlow::<()>::Continue
                 },
                 |pte, ctx| {
                     if range.contains(ctx.vpn) {
+                        if !pte.is_valid() {
+                            kwarningln!(
+                                "Mapper::unmap: trying to unmap an unmapped page: vpn={:?}",
+                                ctx.vpn
+                            );
+                        }
                         *pte = Pte::ZEROED;
                     }
 
@@ -123,8 +204,10 @@ impl Mapper<'_> {
                 },
                 TraverseOrder::PostOrder,
             ) {
-                ControlFlow::Continue => Ok(()),
-                ControlFlow::Break(err) => Err(err),
+                ControlFlow::Continue => {},
+                ControlFlow::Break(err) => {
+                    unreachable!("unexpected break during unmapping: {:?}", err)
+                },
             }
         }
     }
@@ -207,8 +290,11 @@ impl Mapper<'_> {
     /// # Safety
     ///
     /// Use-after-free and double-free may happen if the branch and leaf
-    /// operations deallocate page tables or page mappings. The caller must
+    /// operations deallocate page tables or page mappings. Caller must
     /// ensure that the operations are safe to perform.
+    ///
+    /// TODO: currently we traverse all Ptes, which is inefficient. we should
+    /// support traverse within a given vpn range.
     unsafe fn traverse<B, L, R>(
         &mut self,
         branch_op: B,
@@ -327,7 +413,7 @@ impl Mapper<'_> {
         vpn: VirtPageNum,
         ppn: PhysPageNum,
         flags: PteFlags,
-        remap: bool,
+        overwrite: bool,
     ) -> Result<(), MmError> {
         let levels = PagingArch::PAGE_LEVELS;
         let vpn_bits = PagingArch::PTE_PER_PGDIR.trailing_zeros() as usize;
@@ -347,7 +433,7 @@ impl Mapper<'_> {
 
             if level == 0 {
                 // leaf reached
-                if pte.is_valid() && !remap {
+                if pte.is_valid() && !overwrite {
                     return Err(MmError::AlreadyMapped);
                 }
                 *pte = Pte::new(ppn, flags | PteFlags::VALID);

--- a/anemone-kernel/src/mm/paging/mod.rs
+++ b/anemone-kernel/src/mm/paging/mod.rs
@@ -1,6 +1,6 @@
 //! # Paging Subsystem & Virtual Memory Layout
 //!
-//! The kernel adopts a "Higher Half" memory model. The virtual address space
+//! Anemone adopts the "Higher Half" memory model. The virtual address space
 //! is partitioned into the following primary regions:
 //!
 //! * **User Space (Lower Half):** Occupies the bottom half of the address
@@ -18,9 +18,6 @@
 //! [ 0xffffffc000000000 | Direct Mapping (HHDM)    ] -> Physical memory mirror
 //! [  ...      | Vmmapping                ] -> Dynamic kernel mappings
 //! [ -2GB to 0 | Kernel Image             ] -> Core kernel executable
-
-// mod hal;
-// pub use hal::*;
 
 mod hal;
 pub use hal::*;

--- a/anemone-kernel/src/mm/paging/pagetable.rs
+++ b/anemone-kernel/src/mm/paging/pagetable.rs
@@ -43,17 +43,12 @@ impl Drop for PageTable {
         let mut mapper = self.mapper();
 
         // unmap all pages
-        match mapper.unmap(Unmapping {
+        mapper.unmap(Unmapping {
             range: VirtPageRange::new(
                 VirtPageNum::new(0),
                 1 << (PagingArch::PAGE_LEVELS * PagingArch::PGDIR_IDX_BITS),
             ),
-        }) {
-            Ok(()) => (),
-            Err(e) => {
-                kerrln!("failed to unmap page table: {:#?}", e);
-            },
-        }
+        });
         let _frame = unsafe { Frame::from_ppn(self.root) };
     }
 }

--- a/anemone-kernel/src/mm/percpu.rs
+++ b/anemone-kernel/src/mm/percpu.rs
@@ -1,7 +1,7 @@
 /// Per Cpu data management.
 // TODO: add docs and comments
 use crate::{exception::PreemptCounter, prelude::*};
-use core::cell::UnsafeCell;
+use core::{cell::UnsafeCell, ptr::NonNull};
 
 #[derive(Debug)]
 #[repr(transparent)]

--- a/anemone-kernel/src/mm/remap.rs
+++ b/anemone-kernel/src/mm/remap.rs
@@ -1,0 +1,192 @@
+//! Vmalloc & ioremap
+
+use spin::Lazy;
+
+use crate::{
+    mm::{
+        kpgdir::{kmap, kunmap},
+        layout::KernelLayoutTrait,
+    },
+    prelude::*,
+};
+
+impl range_allocator::Rangable for VirtPageRange {
+    fn start(&self) -> usize {
+        self.start().get() as usize
+    }
+
+    fn len(&self) -> usize {
+        self.npages() as usize
+    }
+
+    fn from_parts(start: usize, length: usize) -> Self {
+        Self::new(VirtPageNum::new(start as u64), length as u64)
+    }
+}
+
+/// System state related to virtual memory remapping, including vmalloc and
+/// ioremap.
+///
+/// All IO remapping are uncached for simplicity. TODO: this is currently
+/// unimplemented.
+///
+/// Currently only ioremap is implementeed.
+#[derive(Debug)]
+struct SysRemaps {
+    range_allocator: range_allocator::RangeAllocator<VirtPageRange>,
+    io_remapped: BTreeMap<PhysPageNum, IoRemapEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IoRemapEntry {
+    phys: PhysPageRange,
+    virt: VirtPageRange,
+}
+
+impl SysRemaps {
+    fn new() -> Self {
+        Self {
+            range_allocator: range_allocator::RangeAllocator::new(),
+            io_remapped: BTreeMap::new(),
+        }
+    }
+
+    fn alloc(&mut self, npages: usize) -> Option<VirtPageRange> {
+        self.range_allocator.allocate(npages)
+    }
+
+    fn free(&mut self, start: VirtPageNum, npages: usize) -> Result<(), MmError> {
+        let range = VirtPageRange::new(start, npages as u64);
+        self.range_allocator
+            .free(range)
+            .map_err(|_| MmError::InvalidArgument)
+    }
+
+    fn find_io_overlap(&self, phys_range: PhysPageRange) -> Option<IoRemapEntry> {
+        let key = phys_range.start();
+
+        if let Some((_, entry)) = self.io_remapped.range(..=key).next_back() {
+            if entry.phys.intersects(&phys_range) {
+                return Some(*entry);
+            }
+        }
+
+        if let Some((_, entry)) = self.io_remapped.range(key..).next() {
+            if entry.phys.intersects(&phys_range) {
+                return Some(*entry);
+            }
+        }
+
+        None
+    }
+}
+
+impl SysRemaps {
+    unsafe fn ioremap(&mut self, phys_range: PhysPageRange) -> Result<VirtPageRange, MmError> {
+        if self.find_io_overlap(phys_range).is_some() {
+            return Err(MmError::AlreadyMapped);
+        }
+
+        let npages = phys_range.npages() as usize;
+        let virt_range = self.alloc(npages).ok_or(MmError::OutOfMemory)?;
+
+        unsafe {
+            kmap(Mapping {
+                vpn: virt_range.start(),
+                ppn: phys_range.start(),
+                npages,
+                flags: PteFlags::READ | PteFlags::WRITE,
+            })
+            .map_err(|e| {
+                self.free(virt_range.start(), virt_range.npages() as usize)
+                    .expect("internal error: failed to free virt range after failed ioremap");
+                e
+            })?;
+        }
+
+        let prev = self.io_remapped.insert(
+            phys_range.start(),
+            IoRemapEntry {
+                phys: phys_range,
+                virt: virt_range,
+            },
+        );
+        assert!(
+            prev.is_none(),
+            "internal error: duplicated ioremap entry after overlap check"
+        );
+
+        Ok(virt_range)
+    }
+
+    unsafe fn iounmap(&mut self, range: PhysPageRange) -> Result<(), MmError> {
+        let key = range.start();
+        let entry = self.io_remapped.get(&key).ok_or(MmError::NotMapped)?;
+
+        if entry.phys != range {
+            return Err(MmError::InvalidArgument);
+        }
+
+        // Invariant checked above. Remove should always succeed here.
+        let entry = self
+            .io_remapped
+            .remove(&key)
+            .expect("internal error: ioremap entry disappeared during iounmap");
+
+        unsafe {
+            kunmap(Unmapping { range: entry.virt });
+        }
+
+        self.free(entry.virt.start(), entry.virt.npages() as usize)
+            .expect("internal error: failed to release virtual range during iounmap");
+
+        Ok(())
+    }
+}
+
+static SYS_REMAPS: Lazy<SpinLock<SysRemaps>> = Lazy::new(|| {
+    let mut remaps = SysRemaps::new();
+    unsafe {
+        let remap_region = KernelLayout::REMAP_REGION;
+        remaps
+            .free(remap_region.start(), remap_region.npages() as usize)
+            .expect("failed to initialize remap region");
+    }
+    SpinLock::new(remaps)
+});
+
+#[derive(Debug)]
+pub struct IoRemap {
+    virt: VirtPageRange,
+    phys: PhysPageRange,
+}
+
+impl Drop for IoRemap {
+    fn drop(&mut self) {
+        unsafe {
+            SYS_REMAPS
+                .lock_irqsave()
+                .iounmap(self.phys)
+                .expect("failed to iounmap in IoRemap drop");
+        }
+    }
+}
+
+/// Remap the given physical page range to a virtual page range in the remap
+/// region, and return the virtual page range.
+///
+/// # Safety
+///
+/// Caller must ensure that the given physical page range is a valid MMIO
+/// region, and that the caller has exclusive access to the given physical page
+/// range.
+pub unsafe fn ioremap(range: PhysPageRange) -> Result<IoRemap, MmError> {
+    unsafe {
+        let virt = SYS_REMAPS.lock_irqsave().ioremap(range)?;
+        Ok(IoRemap { virt, phys: range })
+    }
+}
+
+pub fn vmalloc(npages: usize) -> Option<Todo> {
+    todo!()
+}

--- a/anemone-kernel/src/mm/zone.rs
+++ b/anemone-kernel/src/mm/zone.rs
@@ -1,0 +1,198 @@
+use crate::prelude::*;
+
+use spin::Lazy;
+
+#[derive(Debug, Clone, Copy)]
+pub struct AvailMemZone {
+    start_ppn: PhysPageNum,
+    npages: u64,
+}
+
+impl AvailMemZone {
+    pub const fn new(start_ppn: PhysPageNum, npages: u64) -> Self {
+        Self { start_ppn, npages }
+    }
+
+    pub const fn range(&self) -> PhysPageRange {
+        PhysPageRange::new(self.start_ppn, self.npages)
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct RsvMemFlags: u32 {
+        /// Memory that should not be mapped by the kernel's paging
+        /// subsystem.
+        const NOMAP = 0x0001;
+
+        /// Memory that can be reused by kernel.
+        const REUSABLE = 0x0002;
+
+        /// Kernel image region.
+        const KVIRT = 0x0004;
+
+        /// Memory that can be used for early allocation before
+        /// the frame allocator is initialized.
+        const EARLY_ALLOC = 0x0008;
+
+        /// Memory reserved for the Flattened Device Tree blob.
+        ///
+        /// TODO: This flag is in theory needless. We should use a RECLAIMABLE flag instead.
+        const FDT = 0x0010;
+    }
+}
+
+impl RsvMemFlags {
+    pub fn is_mappable(&self) -> bool {
+        !self.contains(RsvMemFlags::NOMAP)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RsvMemZone {
+    start_ppn: PhysPageNum,
+    npages: u64,
+    flags: RsvMemFlags,
+}
+
+impl RsvMemZone {
+    pub const fn new(start_ppn: PhysPageNum, npages: u64, flags: RsvMemFlags) -> Self {
+        Self {
+            start_ppn,
+            npages,
+            flags,
+        }
+    }
+
+    pub const fn range(&self) -> PhysPageRange {
+        PhysPageRange::new(self.start_ppn, self.npages)
+    }
+
+    pub const fn flags(&self) -> RsvMemFlags {
+        self.flags
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MemZone {
+    Avail(AvailMemZone),
+    Rsv(RsvMemZone),
+}
+
+impl MemZone {
+    pub const fn range(&self) -> PhysPageRange {
+        match self {
+            MemZone::Avail(avail_zone) => avail_zone.range(),
+            MemZone::Rsv(rsv_zone) => rsv_zone.range(),
+        }
+    }
+
+    pub const fn contains(&self, ppn: PhysPageNum) -> bool {
+        self.range().contains(ppn)
+    }
+
+    pub const fn intersects(&self, other: PhysPageRange) -> bool {
+        self.range().intersects(&other)
+    }
+}
+
+/// Memory zones in the system.
+///
+/// This struct is currently mainly used for 2 purposes:
+/// - enforcing the lock ordering of memory zones related locks by exposing safe
+///   accessors, and
+/// - providing a unified interface for memory zones related operations, such as
+///   adding a new memory zone, iterating over all memory zones, etc.
+#[derive(Debug)]
+pub struct SysMemZones {
+    // LOCK ORDERING: MEM_ZONES -> AVAIL_MEM_ZONES -> RSV_MEM_ZONES
+    mem_zones: SpinLock<Vec<MemZone>>,
+    avail_mem_zones: SpinLock<Vec<AvailMemZone>>,
+    rsv_mem_zones: SpinLock<Vec<RsvMemZone>>,
+}
+
+impl SysMemZones {
+    pub fn new() -> Self {
+        Self {
+            mem_zones: SpinLock::new(Vec::new()),
+            avail_mem_zones: SpinLock::new(Vec::new()),
+            rsv_mem_zones: SpinLock::new(Vec::new()),
+        }
+    }
+
+    // following methods are implemented in a pessimistic way by acquiring all
+    // locks, thus incurring more contention and efficiency loss, but they are
+    // therefore easier to reason about and without worrying about lock ordering. We
+    // can optimize them later if needed.
+
+    pub fn with_all_zones<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&[MemZone]) -> R,
+    {
+        let mem_zones = self.mem_zones.lock_irqsave();
+        f(&mem_zones)
+    }
+
+    pub fn with_avail_zones<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&[AvailMemZone]) -> R,
+    {
+        let _mem_zones = self.mem_zones.lock_irqsave();
+        let avail_mem_zones = self.avail_mem_zones.lock_irqsave();
+        f(&avail_mem_zones)
+    }
+
+    pub fn with_rsv_zones<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&[RsvMemZone]) -> R,
+    {
+        let _mem_zones = self.mem_zones.lock_irqsave();
+        let _avail_mem_zones = self.avail_mem_zones.lock_irqsave();
+        let rsv_mem_zones = self.rsv_mem_zones.lock_irqsave();
+        f(&rsv_mem_zones)
+    }
+
+    // some convenient methods for common operations.
+
+    /// Adds a memory zone to the physical memory manager.
+    ///
+    /// # Safety
+    /// The caller must ensure that the memory zone specified by `zone` is valid
+    /// and **does not overlap** with any existing memory zones. The
+    /// behavior is undefined if the caller violates this requirement.
+    ///
+    /// For now, we panic immediately if any invariant is violated in dev build,
+    /// thus catching bugs as early as possible.
+    ///
+    /// TODO: support reclaimable reserved memory regions.
+    pub unsafe fn add_mem_zone(&self, zone: MemZone) {
+        let mut mem_zones = self.mem_zones.lock_irqsave();
+        let mut avail_mem_zones = self.avail_mem_zones.lock_irqsave();
+        let mut rsv_mem_zones = self.rsv_mem_zones.lock_irqsave();
+
+        #[cfg(debug_assertions)]
+        {
+            // check for overlaps with existing zones.
+            for existing_zone in mem_zones.iter() {
+                if zone.intersects(existing_zone.range()) {
+                    panic!(
+                        "new memory zone {:x?} overlaps with existing zone {:x?}",
+                        zone, existing_zone
+                    );
+                }
+            }
+        }
+
+        mem_zones.push(zone);
+        match zone {
+            MemZone::Avail(avail_zone) => avail_mem_zones.push(avail_zone),
+            MemZone::Rsv(rsv_zone) => rsv_mem_zones.push(rsv_zone),
+        }
+    }
+}
+
+static SYS_MEM_ZONES: Lazy<SysMemZones> = Lazy::new(SysMemZones::new);
+
+pub fn sys_mem_zones<'a>() -> &'a SysMemZones {
+    &SYS_MEM_ZONES
+}

--- a/anemone-kernel/src/panic.rs
+++ b/anemone-kernel/src/panic.rs
@@ -1,10 +1,15 @@
 // TODO: a better panic handler with more information
-// TODO: if an ap panics, it should notify the bsp.
 
 use crate::prelude::*;
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
+    broadcast_ipi(IpiPayload::StopExecution, false);
+
+    // TODO: What if other CPUs are already stuck due to some other cause? Then
+    // following code will never be executed, and shutdown will never be called.
+    // we should implement async IPIs to handle this case.
+
     kemergln!("Kernel panic:\n{}", info);
     unsafe { PowerArch::shutdown() }
 }

--- a/anemone-kernel/src/prelude.rs
+++ b/anemone-kernel/src/prelude.rs
@@ -2,9 +2,9 @@ pub use crate::{
     arch::*,
     device::{error::*, *},
     driver::*,
-    exception::intr::*,
+    exception::{intr::*, *},
     kconfig_defs::*,
-    mm::{addr::*, error::*, frame::*, paging::*, percpu::*},
+    mm::{addr::*, error::*, frame::*, paging::*, percpu::*, zone::*},
     platform_defs::*,
     power::*,
     sched::*,
@@ -17,11 +17,17 @@ pub use crate::{
 };
 pub use alloc::{
     boxed::Box,
+    collections::{BTreeMap, BTreeSet},
     format,
     string::{String, ToString},
     sync::{Arc, Weak},
     vec,
     vec::Vec,
 };
-pub use core::{sync::atomic::Ordering, time::Duration};
+
+pub use core::{pin::Pin, sync::atomic::*, time::Duration};
 pub use kernel_macros::*;
+
+pub use bitflags::bitflags;
+pub use hashbrown::{HashMap, HashSet};
+pub use intrusive_collections::{LinkedList, LinkedListLink, intrusive_adapter};

--- a/anemone-kernel/src/utils/writer.rs
+++ b/anemone-kernel/src/utils/writer.rs
@@ -43,7 +43,7 @@ impl<const OVERFLOW_BEHAVIOR: usize> Write for BufferWriter<'_, OVERFLOW_BEHAVIO
             match OVERFLOW_BEHAVIOR {
                 OverflowBehavior::PANIC => {
                     panic!("Buffer overflow in BufferWriter");
-                }
+                },
                 OverflowBehavior::TRUNCATE => {
                     // Silently truncate the output if it exceeds the buffer size. This is useful
                     // for log messages where we don't want to panic even if the message is too
@@ -51,10 +51,10 @@ impl<const OVERFLOW_BEHAVIOR: usize> Write for BufferWriter<'_, OVERFLOW_BEHAVIO
                     let available = self.buf.len() - self.pos;
                     self.buf[self.pos..].copy_from_slice(&bytes[..available]);
                     self.pos += available;
-                }
+                },
                 OverflowBehavior::RETURN_ERROR => {
                     return Err(core::fmt::Error);
-                }
+                },
                 _ => unreachable!(),
             }
         } else {

--- a/conf/.defconfig
+++ b/conf/.defconfig
@@ -21,6 +21,7 @@ bootstrap_heap_shift_kb = 10 # Size of bootstrap heap as a power of 2 in KB
 log_buffer_shift_kb = 9 # Log buffer size as a power of 2 in KB, excluding metadata overhead
 log_record_shift_bytes = 9 # Log record size as a power of 2 in bytes
 kstack_shift_kb = 5 # Kernel stack size as a power of 2 in KB
+remap_shift_gb = 6 # Size of remap region as a power of 2 in GB
 max_ident_len_bytes = 256 # Maximum length of identity strings in bytes.
 max_processes = 128 # Maximum number of processes
 time_slice_ms = 10 # Time slice duration in milliseconds

--- a/conf/arch/riscv64/kernel.lds.in
+++ b/conf/arch/riscv64/kernel.lds.in
@@ -43,12 +43,11 @@ SECTIONS {
         *(.percpu.core_local)
         *(.percpu)
         __epercpu = .;
-        # If needed, we can add more initcall sections with different priorities, e.g. .initcall.1, .initcall.3, etc.
-        # but for now one is enough for our simple kernel.
-        . = ALIGN(8);
+        
         __sinitcall_driver = .;
         *(.initcall.driver .initcall.driver.*)
         __einitcall_driver = .;
+
         __edata = .;
     } > VIRT AT> RAM
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-01-31"
+channel = "nightly-2026-03-07"
 profile = "minimal"
 components = [
     "rustfmt",

--- a/scripts/xtask/src/config/kconfig.rs
+++ b/scripts/xtask/src/config/kconfig.rs
@@ -37,6 +37,7 @@ pub struct Parameters {
     pub log_buffer_shift_kb: Option<u64>,
     pub log_record_shift_bytes: Option<u64>,
     pub kstack_shift_kb: Option<u64>,
+    pub remap_shift_gb: Option<u64>,
     pub max_ident_len_bytes: Option<usize>,
     pub max_processes: Option<u64>,
     pub time_slice_ms: Option<u64>,
@@ -78,6 +79,8 @@ pub const LOG_BUFFER_SHIFT_KB: u64 = {};
 pub const LOG_RECORD_SHIFT_BYTES: u64 = {};
 /// Kernel stack size as a power of 2 in KB
 pub const KSTACK_SHIFT_KB: u64 = {};
+/// Remap region size as a power of 2 in GB
+pub const REMAP_SHIFT_GB: u64 = {};
 /// Maximum length of identity strings in bytes
 pub const MAX_IDENT_LEN_BYTES: usize = {};
 /// Maximum length of file names in bytes. This is always equal to MAX_IDENT_LEN_BYTES,
@@ -94,6 +97,7 @@ pub const SYSTEM_HZ: u16 = {};
             default_or!(log_buffer_shift_kb),
             default_or!(log_record_shift_bytes),
             default_or!(kstack_shift_kb),
+            default_or!(remap_shift_gb),
             default_or!(max_ident_len_bytes),
             default_or!(max_processes),
             default_or!(time_slice_ms),

--- a/scripts/xtask/src/tasks/build/mod.rs
+++ b/scripts/xtask/src/tasks/build/mod.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use xshell::Shell;
 
 use crate::{
-    config::{KConfig, PlatformConfig, kconfig::Profile},
+    config::{kconfig::Profile, KConfig, PlatformConfig},
     log_progress, warn,
     workspace::*,
 };
@@ -142,6 +142,7 @@ impl<'a> BuildContext<'a> {
                 "-Z", // Refer to https://github.com/rust-lang/wg-cargo-std-aware/issues/53 for why this is needed
                 "build-std-features=compiler-builtins-mem",
             ])
+            .args(&["-Z", "json-target-spec"])
             .arg("--target")
             .arg(&format!(
                 "../conf/arch/{}/{}.json",


### PR DESCRIPTION
This PR mainly includes the following changes:
- remap module for ioremap and vmalloc, with the former implemented currently,
- IPI framework, with synchronous IPI implemented, and
- mm module minor refactor.

Misc changes include:
- A new crate range-allocator, currently used for managing kernel's remap region.