### PR TITLE
Page Metadata Tracking

### DIFF
--- a/anemone-kernel/src/arch/riscv64/bootstrap.rs
+++ b/anemone-kernel/src/arch/riscv64/bootstrap.rs
@@ -231,6 +231,12 @@ extern "C" fn rusty_nun(hart_id: usize, fdt_pa: PhysAddr) -> ! {
 unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
     unsafe {
         clear_bss();
+
+        // set up kernel trap handler
+        on_enter_kernel();
+        riscv::register::sstatus::set_sie();
+        // enable ipi
+        riscv::register::sie::set_ssoft();
     }
     register_earlycon();
 
@@ -259,6 +265,15 @@ unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
         kinfoln!("percpu data initialized");
 
         scanner.commit_to_pmm();
+        let mut memmap_pages = 0;
+        mm::frame::memmap_init(|npages| {
+            memmap_pages += npages;
+            kdebugln!("memmap init: allocating {} pages", npages);
+            sys_mem_zones()
+                .leak(npages)
+                .expect("no enough memory to initialize memmap")
+        });
+        kdebugln!("memmap initialized, total {} pages", memmap_pages);
         mm::frame::pmm_init();
         kinfoln!("physical memory management initialized");
 
@@ -272,12 +287,6 @@ unsafe fn bsp_entry(bsp_id: usize, fdt_pa: PhysAddr) -> ! {
 
         unflatten_device_tree(fdt_va);
         of_platform_discovery();
-
-        // set up kernel trap handler
-        on_enter_kernel();
-        riscv::register::sstatus::set_sie();
-        // enable ipi
-        riscv::register::sie::set_ssoft();
 
         // okay, we can wake up APs now.
         {

--- a/anemone-kernel/src/arch/riscv64/mm/sv39.rs
+++ b/anemone-kernel/src/arch/riscv64/mm/sv39.rs
@@ -11,6 +11,9 @@ pub struct Sv39PagingArch;
 impl PagingArchTrait for Sv39PagingArch {
     type PgDir = super::RiscV64PgDir;
 
+    /// On RiscV64, maximum length of physical addresses is 56 bits.
+    const MAX_PPN_BITS: usize = 44;
+
     const PAGE_SIZE_BYTES: usize = super::PAGE_SIZE_BYTES;
 
     const PAGE_LEVELS: usize = 3;

--- a/anemone-kernel/src/device/discovery/open_firmware.rs
+++ b/anemone-kernel/src/device/discovery/open_firmware.rs
@@ -32,14 +32,12 @@ mod early {
     use super::*;
 
     #[derive(Debug)]
-    pub struct EarlyMemoryScanner<'a> {
-        _lifetime: PhantomData<&'a ()>,
-
-        avail_set: rangemap::RangeSet<u64>, // ppn, not addr
+    pub struct EarlyMemoryScanner {
+        avail_set: rangemap::RangeSet<u64>,            // ppn, not addr
         rsv_map: rangemap::RangeMap<u64, RsvMemFlags>, // ppn, not addr
     }
 
-    impl EarlyMemoryScanner<'_> {
+    impl EarlyMemoryScanner {
         /// Scan the memory layout (including reserved memory regions) from the
         /// device tree, and return an [EarlyMemoryScanner] instance that holds
         /// the scanned information for later use.
@@ -155,11 +153,10 @@ mod early {
                     __ekernel
                 );
 
-                Self {
-                    _lifetime: PhantomData,
-                    avail_set,
-                    rsv_map,
-                }
+                // 0 is reserved for null pointer semantics.
+                avail_set.remove(0..1);
+
+                Self { avail_set, rsv_map }
             }
         }
 
@@ -323,7 +320,9 @@ pub unsafe fn unflatten_device_tree(fdt_va: VirtAddr) {
         unsafe { Some(NonNull::new_unchecked(ptr)) }
     });
 
-    DEVICE_TREE.init(|| Arc::new(DeviceTree { handle }));
+    DEVICE_TREE.init(|dt| {
+        dt.write(Arc::new(DeviceTree { handle }));
+    });
 }
 
 /// Traverse the unflattened device tree and create devices accordingly.

--- a/anemone-kernel/src/mm/addr.rs
+++ b/anemone-kernel/src/mm/addr.rs
@@ -2,7 +2,7 @@
 
 use crate::{int_like, mm::layout::KernelLayoutTrait, prelude::*};
 use core::{
-    fmt::Display,
+    fmt::{Debug, Display},
     ops::{Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, Not, Sub, SubAssign},
 };
 
@@ -141,13 +141,13 @@ impl VirtPageNum {
 
 macro_rules! impl_page_range {
     ($name:ident, $pn_type:ty) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash)]
         pub struct $name {
             start: $pn_type,
             npages: u64,
         }
         paste::paste! {
-            #[derive(Debug, Clone, Copy)]
+            #[derive(Clone, Copy)]
             pub struct [<$name Iter>] {
                 range: $name,
                 next: $pn_type,
@@ -207,6 +207,30 @@ macro_rules! impl_page_range {
 
 impl_page_range!(PhysPageRange, PhysPageNum);
 impl_page_range!(VirtPageRange, VirtPageNum);
+
+impl Debug for PhysPageRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "[{:#x}, {:#x}) ({} pages)",
+            self.start.to_phys_addr().get(),
+            self.end().to_phys_addr().get(),
+            self.npages
+        )
+    }
+}
+
+impl Debug for VirtPageRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "[{:#x}, {:#x}) ({} pages)",
+            self.start.to_virt_addr().get(),
+            self.end().to_virt_addr().get(),
+            self.npages
+        )
+    }
+}
 
 impl PhysAddr {
     pub fn to_hhdm(self) -> VirtAddr {

--- a/anemone-kernel/src/mm/error.rs
+++ b/anemone-kernel/src/mm/error.rs
@@ -11,6 +11,8 @@ pub enum MmError {
     AlreadyMapped,
     /// The virtual address is not mapped.
     NotMapped,
+    /// The physical frame is held by multiple owners.
+    SharedFrame,
     /// General invalid argument, e.g. an free operation with an invalid address
     /// or length.
     InvalidArgument,

--- a/anemone-kernel/src/mm/frame/allocator.rs
+++ b/anemone-kernel/src/mm/frame/allocator.rs
@@ -1,4 +1,12 @@
 //! TODO: add FrameOomHandler trait
+//!
+//! **NOTE**
+//!
+//! medadata in memmap is not maintained here. the allocator only serves as an
+//! algorithm to allocate and deallocate physical pages.
+//!
+//! metadata is maintained, instead, in [crate::mm::frame::managed] module, with
+//! RAII types to ensure safety.
 
 use crate::prelude::*;
 
@@ -74,21 +82,19 @@ impl<A: FrameAllocator> LockedFrameAllocator<A> {
         }
     }
 
-    pub fn alloc(&self, npages: usize) -> Option<Folio> {
-        let mut allocator = self.allocator.lock_irqsave();
-        let start_ppn = allocator.alloc(npages)?;
+    pub fn alloc(&self, npages: usize) -> Option<OwnedFolio> {
+        let start_ppn = self.allocator.lock_irqsave().alloc(npages)?;
         unsafe {
-            Some(Folio::from_range(PhysPageRange::new(
+            Some(OwnedFolio::new(PhysPageRange::new(
                 start_ppn,
                 npages as u64,
             )))
         }
     }
 
-    pub fn alloc_one(&self) -> Option<Frame> {
-        let mut allocator = self.allocator.lock_irqsave();
-        let start_ppn = allocator.alloc(1)?;
-        unsafe { Some(Frame::from_ppn(start_ppn)) }
+    pub fn alloc_one(&self) -> Option<OwnedFrameHandle> {
+        let start_ppn = self.allocator.lock_irqsave().alloc(1)?;
+        unsafe { Some(OwnedFrameHandle::new(start_ppn)) }
     }
 
     pub unsafe fn add_range(&self, range: PhysPageRange) {

--- a/anemone-kernel/src/mm/frame/managed.rs
+++ b/anemone-kernel/src/mm/frame/managed.rs
@@ -1,59 +1,110 @@
-//! TODO: reference counting for shared ownership. idk whether simply using Arc
-//! is sufficient or we need to implement an intrusive one.
+//! RAII wrapper around physical frames.
 
 use core::mem::ManuallyDrop;
 
 use crate::{mm::frame::FRAME_ALLOCATOR, prelude::*};
 
-/// A physical frame of memory.
-///
-/// RAII wrapper around a [`PhysPageNum`] that represents a minimal unit of
-/// physical memory that can be allocated and deallocated, i.e. PAGE_SIZE_BYTES.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Frame {
+#[derive(Debug)]
+pub struct FrameHandle {
     ppn: PhysPageNum,
 }
 
-impl Frame {
-    /// Creates a new `Frame` from the given physical page number.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that it has the ownership of the physical page
-    /// specified by `ppn`.
-    pub unsafe fn from_ppn(ppn: PhysPageNum) -> Self {
-        Self { ppn }
-    }
+#[derive(Debug)]
+pub struct OwnedFrameHandle {
+    inner: FrameHandle,
+}
 
+impl TryFrom<FrameHandle> for OwnedFrameHandle {
+    type Error = (MmError, FrameHandle);
+
+    fn try_from(value: FrameHandle) -> Result<Self, Self::Error> {
+        if unsafe { get_frame(value.ppn) }.is_shared() {
+            Err((MmError::SharedFrame, value))
+        } else {
+            Ok(Self { inner: value })
+        }
+    }
+}
+
+impl FrameHandle {
+    /// Returns the physical page number of the frame represented by this
+    /// handle.
     pub fn ppn(&self) -> PhysPageNum {
         self.ppn
     }
 
-    /// Leaks the `Frame`, returning the underlying physical page number without
-    /// deallocating it.
+    /// Try to convert this `FrameHandle` into an `OwnedFrameHandle`.
+    ///
+    /// This will fail if the underlying frame is shared, since we cannot
+    /// guarantee the ownership of a shared frame.
+    pub fn try_into_owned(self) -> Result<OwnedFrameHandle, (MmError, FrameHandle)> {
+        OwnedFrameHandle::try_from(self)
+    }
+}
+
+impl OwnedFrameHandle {
+    /// Creates a new `OwnedFrameHandle` from the given physical page number.
+    ///
+    /// # Safety
+    ///
+    /// **Do not use this.**
+    ///
+    /// This funciton is only used by frame allocator when creating a new
+    /// RAII handle for a newly allocated frame.
+    pub unsafe fn new(ppn: PhysPageNum) -> Self {
+        unsafe {
+            #[cfg(debug_assertions)]
+            assert!(get_frame(ppn).is_free());
+
+            get_frame(ppn).inc_ref();
+        }
+
+        Self {
+            inner: FrameHandle { ppn },
+        }
+    }
+
+    /// Creates an `OwnedFrameHandle` from the given physical page number.
+    ///
+    /// # Safety
+    ///
+    /// `ppn` must be a valid physical page number that was leaked previously by
+    /// caller, and caller now has the exclusive ownership of the corresponding
+    /// physical frame.
+    pub unsafe fn from_ppn(ppn: PhysPageNum) -> Self {
+        unsafe {
+            #[cfg(debug_assertions)]
+            assert!(get_frame(ppn).rc() == 1);
+        }
+        Self {
+            inner: FrameHandle { ppn },
+        }
+    }
+
+    /// Leak the `OwnedFrameHandle`, returning the underlying physical page
+    /// number without deallocating it.
     ///
     /// Rust does not consider leaking memory to be unsafe, so we keep this
     /// function safe. However, one should always be careful when using this
     /// function, as it can easily lead to OOM.
+    ///
+    /// To transform the leaked frame back into a `OwnedFrameHandle`, use
+    /// [OwnedFrameHandle::from_ppn] instead of [OwnedFrameHandle::new].
     pub fn leak(self) -> PhysPageNum {
-        let frame = ManuallyDrop::new(self);
-        frame.ppn
+        ManuallyDrop::new(self).inner.ppn
     }
 
     /// Returns a byte slice that represents the contents of the physical frame.
     ///
     /// **The slice created by this function points to HHDM region.**
     ///
-    /// This function is safe because the [crate::Frame] represents an **owned**
-    /// physical page, and thus we have the exclusive right to access it.
-    ///
-    /// However, one should be careful when using this function, as it can
-    /// easily lead to undefined behavior if the caller violates the ownership
-    /// requirement of the [crate::Frame].
+    /// This function is safe because the [OwnedFrameHandle] represents an
+    /// **owned** physical page, and thus we have the exclusive right to
+    /// access it.
     pub fn as_bytes(&self) -> &'_ [u8] {
         unsafe {
             core::slice::from_raw_parts(
-                self.ppn.to_phys_addr().to_hhdm().as_ptr(),
+                self.inner.ppn.to_phys_addr().to_hhdm().as_ptr(),
                 PagingArch::PAGE_SIZE_BYTES,
             )
         }
@@ -64,80 +115,164 @@ impl Frame {
     ///
     /// **The slice created by this function points to HHDM region.**
     ///
-    /// This function is safe because the [crate::Frame] represents an **owned**
-    /// physical page, and thus we have the exclusive right to access it.
-    ///
-    /// However, one should be careful when using this function, as it can
-    /// easily lead to undefined behavior if the caller violates the ownership
-    /// requirement of the [crate::Frame].
+    /// This function is safe because the [OwnedFrameHandle] represents an
+    /// **owned** physical page, and thus we have the exclusive right to
+    /// access it.
     pub fn as_bytes_mut(&mut self) -> &'_ mut [u8] {
         unsafe {
             core::slice::from_raw_parts_mut(
-                self.ppn.to_phys_addr().to_hhdm().as_ptr_mut(),
+                self.inner.ppn.to_phys_addr().to_hhdm().as_ptr_mut(),
                 PagingArch::PAGE_SIZE_BYTES,
             )
         }
     }
+
+    /// Converts this [OwnedFrameHandle] into a [FrameHandle].
+    ///
+    /// # Safety
+    ///
+    /// Caller should not 'leak' any exclusively accessible resource after
+    /// calling this function.
+    pub unsafe fn into_frame_handle(self) -> FrameHandle {
+        self.inner
+    }
 }
 
-impl Drop for Frame {
+impl Drop for FrameHandle {
     fn drop(&mut self) {
         unsafe {
-            FRAME_ALLOCATOR.dealloc(PhysPageRange::new(self.ppn, 1));
+            let frame = get_frame(self.ppn);
+            frame.dec_ref();
+            if frame.is_free() {
+                FRAME_ALLOCATOR.dealloc(PhysPageRange::new(self.ppn, 1));
+            }
         }
     }
 }
 
 /// RAII wrapper around a contiguous range of physical frames.
 ///
-/// Currently no huge page support is implemented, so a `Folio` is just a
-/// wrapper around a vector of `Frame`s.
-#[derive(Debug, PartialEq, Eq)]
+/// `Folio` represents a batched ownership of multiple physical pages, and one
+/// should not try to split a `Folio` into multiple `FrameHandle`s, as it can
+/// easily lead to undefined behavior if the caller violates the ownership
+/// requirement of the `Folio`.
+#[derive(Debug)]
 pub struct Folio {
-    start_ppn: PhysPageNum,
-    npages: u64,
+    range: PhysPageRange,
+}
+
+#[derive(Debug)]
+pub struct OwnedFolio {
+    inner: Folio,
+}
+
+impl TryFrom<Folio> for OwnedFolio {
+    type Error = (MmError, Folio);
+
+    fn try_from(value: Folio) -> Result<Self, Self::Error> {
+        for i in 0..value.range.npages() {
+            if unsafe { get_frame(value.range.start() + i) }.is_shared() {
+                return Err((MmError::SharedFrame, value));
+            }
+        }
+        Ok(Self { inner: value })
+    }
 }
 
 impl Folio {
-    /// Creates a `Folio` from the given physical page range.
+    /// Returns the physical page range of the folio.
+    pub fn range(&self) -> PhysPageRange {
+        self.range
+    }
+
+    /// Try to convert this `Folio` into an `OwnedFolio`.
+    ///
+    /// This will fail if any of the underlying frames is shared, since we
+    /// cannot guarantee the ownership of a shared frame.
+    pub fn try_into_owned(self) -> Result<OwnedFolio, (MmError, Folio)> {
+        OwnedFolio::try_from(self)
+    }
+}
+
+impl OwnedFolio {
+    /// Creates a new `OwnedFolio` from the given physical page range.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that it has the ownership of the physical pages
-    /// specified by `range`. The behavior is undefined if the caller violates
-    /// this requirement.
-    pub unsafe fn from_range(range: PhysPageRange) -> Self {
-        Self {
-            start_ppn: range.start(),
-            npages: range.npages(),
+    /// **Do not use this.**
+    ///
+    /// This funciton is only used by frame allocator when creating a new
+    /// RAII handle for a newly allocated folio.
+    pub unsafe fn new(range: PhysPageRange) -> Self {
+        unsafe {
+            #[cfg(debug_assertions)]
+            {
+                for i in 0..range.npages() {
+                    assert!(get_frame(range.start() + i).is_free());
+                }
+            }
+
+            for i in 0..range.npages() {
+                get_frame(range.start() + i).inc_ref();
+            }
+
+            Self {
+                inner: Folio { range },
+            }
         }
     }
 
-    pub fn range(&self) -> PhysPageRange {
-        PhysPageRange::new(self.start_ppn, self.npages)
+    /// Creates an `OwnedFolio` from the given physical page range.
+    ///
+    /// # Safety
+    ///
+    /// `range` must be a valid physical page range that was leaked previously
+    /// by caller, and caller now has the exclusive ownership of the
+    /// corresponding physical frames.
+    pub unsafe fn from_range(range: PhysPageRange) -> Self {
+        unsafe {
+            #[cfg(debug_assertions)]
+            {
+                for i in 0..range.npages() {
+                    assert_eq!(
+                        get_frame(range.start() + i).rc(),
+                        1,
+                        "Internal error: frames in the same folio have different reference counts"
+                    );
+                }
+            }
+        }
+
+        Self {
+            inner: Folio { range },
+        }
     }
 
-    /// Leaks the `Folio`, returning the underlying physical page range without
-    /// deallocating it.
+    /// Leaks the `OwnedFolio`, returning the underlying physical page range
+    /// without deallocating it.
     ///
     /// Rust does not consider leaking memory to be unsafe, so we keep this
     /// function safe. However, one should always be careful when using this
     /// function, as it can easily lead to OOM.
+    ///
+    /// To transform the leaked frames back into an `OwnedFolio`, use
+    /// [OwnedFolio::from_range] instead of [OwnedFolio::new].
     pub fn leak(self) -> PhysPageRange {
         let folio = ManuallyDrop::new(self);
-        PhysPageRange::new(folio.start_ppn, folio.npages)
+        folio.inner.range()
     }
 
     /// Returns a byte slice that represents the contents of the physical folio.
     ///
     /// **The slice created by this function points to HHDM region.**
     ///
-    /// See [`Frame::as_bytes`] for safety and usage notes.
+    /// This function is safe because the [OwnedFolio] represents an **owned**
+    /// physical page range, and thus we have the exclusive right to access it.
     pub fn as_bytes(&self) -> &'_ [u8] {
         unsafe {
             core::slice::from_raw_parts(
-                self.start_ppn.to_phys_addr().to_hhdm().as_ptr(),
-                (self.npages as usize) * PagingArch::PAGE_SIZE_BYTES,
+                self.inner.range.start().to_phys_addr().to_hhdm().as_ptr(),
+                (self.inner.range.npages() as usize) * PagingArch::PAGE_SIZE_BYTES,
             )
         }
     }
@@ -147,21 +282,57 @@ impl Folio {
     ///
     /// **The slice created by this function points to HHDM region.**
     ///
-    /// See [`Frame::as_bytes_mut`] for safety and usage notes.
+    /// This function is safe because the [OwnedFolio] represents an **owned**
+    /// physical page range, and thus we have the exclusive right to access it.
     pub fn as_bytes_mut(&mut self) -> &'_ mut [u8] {
         unsafe {
             core::slice::from_raw_parts_mut(
-                self.start_ppn.to_phys_addr().to_hhdm().as_ptr_mut(),
-                (self.npages as usize) * PagingArch::PAGE_SIZE_BYTES,
+                self.inner
+                    .range
+                    .start()
+                    .to_phys_addr()
+                    .to_hhdm()
+                    .as_ptr_mut(),
+                (self.inner.range.npages() as usize) * PagingArch::PAGE_SIZE_BYTES,
             )
         }
+    }
+
+    /// Converts this [OwnedFolio] into a [Folio].
+    ///
+    /// # Safety
+    ///
+    /// Caller should not 'leak' any exclusively accessible resource after
+    /// calling this function.
+    pub unsafe fn into_folio(self) -> Folio {
+        self.inner
     }
 }
 
 impl Drop for Folio {
     fn drop(&mut self) {
         unsafe {
-            FRAME_ALLOCATOR.dealloc(PhysPageRange::new(self.start_ppn, self.npages));
+            #[cfg(debug_assertions)]
+            {
+                let rc = get_frame(self.range.start()).rc();
+                for i in 1..self.range.npages() {
+                    assert_eq!(
+                        get_frame(self.range.start() + i).rc(),
+                        rc,
+                        "Internal error: frames in the same folio have different reference counts"
+                    );
+                }
+            }
+
+            let rc = get_frame(self.range.start()).rc();
+            for i in 0..self.range.npages() {
+                let ppn = self.range.start() + i;
+                let frame = get_frame(ppn);
+                frame.dec_ref();
+            }
+            if rc == 1 {
+                FRAME_ALLOCATOR.dealloc(self.range);
+            }
         }
     }
 }

--- a/anemone-kernel/src/mm/frame/memmap.rs
+++ b/anemone-kernel/src/mm/frame/memmap.rs
@@ -1,0 +1,387 @@
+//! Memmap, tracking metadata of all physical frames.
+//!
+//! PPN is split into two parts: the lower part is the in-section idx, and
+//! the higher part are indirect levels. Each indirect level has
+//! BITS_PER_INDIRECT_LEVEL bits. I.e.:
+//!
+//! PPN = [indirect level n idx][...][indirect level 1 idx][in-section idx]
+//!
+//! the design can be regarded as a redix tree.
+//!
+//! Anemone's memmap is a bit different from Linux's, as we only track metadata
+//! of available memory, while Linux tracks all RAM pages.
+
+use core::ptr::NonNull;
+
+use crate::prelude::*;
+
+const FRAME_IN_SECTION_IDX_BITS: usize = {
+    let frame_section_shift_bytes = FRAME_SECTION_SHIFT_MB + 20;
+    frame_section_shift_bytes - PagingArch::PAGE_SIZE_BITS
+};
+const BITS_PER_INDIRECT_LEVEL: usize = {
+    static_assert!(size_of::<PhysPageNum>().is_multiple_of(8));
+    PagingArch::PAGE_SIZE_BITS - size_of::<PhysPageNum>().trailing_zeros() as usize
+};
+
+const NINDIRECT_LEVELS: usize = {
+    let total_indirect_bits = PagingArch::MAX_PPN_BITS - FRAME_IN_SECTION_IDX_BITS;
+    align_up!(total_indirect_bits, BITS_PER_INDIRECT_LEVEL) / BITS_PER_INDIRECT_LEVEL
+};
+static_assert!(NINDIRECT_LEVELS > 0);
+const ENTRIES_PER_INDIRECT_LEVEL: usize = PagingArch::PAGE_SIZE_BYTES / size_of::<PhysPageNum>();
+
+// how many pages a MemSection occupies.
+const MEMSECTION_NPAGES: usize = size_of::<MemSection>() / PagingArch::PAGE_SIZE_BYTES;
+// how many `Frame`s a MemSection contains.
+const NFRAMES_PER_SECTION: usize = 1 << FRAME_IN_SECTION_IDX_BITS;
+
+/// Indirect level is just an array with size of PAGE_SIZE_BYTES, containing
+/// PPNs pointing to next level indirect blocks or frame sections.
+#[derive(Debug)]
+#[repr(C)]
+struct IndirectLevel {
+    entries: [PhysPageNum; ENTRIES_PER_INDIRECT_LEVEL],
+}
+static_assert!(size_of::<IndirectLevel>() == PagingArch::PAGE_SIZE_BYTES);
+impl IndirectLevel {
+    const EMPTY: Self = Self {
+        entries: [PhysPageNum::new(0); ENTRIES_PER_INDIRECT_LEVEL],
+    };
+}
+
+#[derive(Debug)]
+struct MemSection {
+    frames: [Frame; 1 << FRAME_IN_SECTION_IDX_BITS],
+}
+static_assert!(size_of::<MemSection>().is_multiple_of(PagingArch::PAGE_SIZE_BYTES));
+
+impl MemSection {
+    const EMPTY: Self = Self {
+        frames: [Frame::EMPTY; 1 << FRAME_IN_SECTION_IDX_BITS],
+    };
+}
+
+mod memmap {
+
+    use core::mem::MaybeUninit;
+
+    use super::*;
+    static MEMMAP: MonoOnce<IndirectLevel> = unsafe { MonoOnce::new() };
+
+    #[inline]
+    fn indirect_indices_for(ppn: PhysPageNum) -> [usize; NINDIRECT_LEVELS] {
+        // Top-level index may have fewer bits than regular levels.
+        let top_level_idx = ppn.get()
+            >> (FRAME_IN_SECTION_IDX_BITS + (NINDIRECT_LEVELS - 1) * BITS_PER_INDIRECT_LEVEL);
+
+        let mut indices = [0; NINDIRECT_LEVELS];
+        let mut shift = FRAME_IN_SECTION_IDX_BITS;
+        for i in 0..NINDIRECT_LEVELS - 1 {
+            indices[i] = ((ppn.get() >> shift) & ((1 << BITS_PER_INDIRECT_LEVEL) - 1)) as usize;
+            shift += BITS_PER_INDIRECT_LEVEL;
+        }
+        indices[NINDIRECT_LEVELS - 1] = top_level_idx as usize;
+        indices
+    }
+
+    /// dry run.
+    ///
+    /// After this function is called, we allocate required pages for memmap,
+    /// using them stroing [Frame]s.
+    ///
+    /// However, when we perform the dry run, we have not yet allocated there
+    /// frames. This portion of memory will leak, and [Frame]s don't track
+    /// them, so we may end up over-allocating memory for memmap.
+    ///
+    /// But is't fine. Those leaked pages will never be allocated, so we
+    /// won't have chance to access their corresponding [Frame]s.
+    fn calculate_memmap_npages() -> usize {
+        let section_mask = (NFRAMES_PER_SECTION as u64) - 1;
+        let section_stride = NFRAMES_PER_SECTION as u64;
+
+        // Keyed by section base PPN (aligned to section size).
+        let mut section_keys = HashSet::new();
+        // Keyed by (level i in init loop, ppn_prefix_at_level_i).
+        // This models each unique indirect page allocated by:
+        // for i in (1..NINDIRECT_LEVELS).rev() { if entry == 0 { alloc(1) } }
+        let mut indirect_keys = HashSet::new();
+
+        sys_mem_zones().with_avail_zones(|zones| {
+            for zone in zones {
+                let range = zone.range();
+                if range.npages() == 0 {
+                    continue;
+                }
+
+                let end_ppn = range.end().get();
+                let mut section_base = range.start().get() & !section_mask;
+
+                while section_base < end_ppn {
+                    section_keys.insert(section_base);
+
+                    for i in 1..NINDIRECT_LEVELS {
+                        let shift = FRAME_IN_SECTION_IDX_BITS + i * BITS_PER_INDIRECT_LEVEL;
+                        let prefix = section_base >> shift;
+                        indirect_keys.insert((i, prefix));
+                    }
+
+                    section_base += section_stride;
+                }
+            }
+        });
+
+        section_keys.len() * MEMSECTION_NPAGES + indirect_keys.len()
+    }
+
+    /// Initialize system memmap.
+    ///
+    /// This function must be called right before
+    /// [device::discovery::open_firmware::EarlyMemoryScanner::commit_to_pmm]
+    /// and before [pmm_init].
+    ///
+    /// The `allocator` receives the number of pages to allocate, and returns
+    /// the PPN of the first allocated page. If no available memory can be
+    /// allocated, an immediate panic should be triggered, since kernel
+    /// cannot run without memmap.
+    pub unsafe fn init<A>(mut allocator: A)
+    where
+        A: FnOnce(usize) -> PhysPageNum,
+    {
+        let npages = calculate_memmap_npages();
+        let sppn = allocator(npages);
+
+        struct Bump {
+            next_ppn: PhysPageNum,
+            npages: usize,
+        }
+
+        impl Bump {
+            fn alloc(&mut self, npages: usize) -> PhysPageNum {
+                if self.npages < npages {
+                    panic!(
+                        "Internal error: we overcalculated memmap npages, but still run out of memory when initializing memmap"
+                    );
+                }
+                let allocated_ppn = self.next_ppn;
+                self.next_ppn += npages as u64;
+                self.npages -= npages;
+                allocated_ppn
+            }
+        }
+
+        impl Drop for Bump {
+            fn drop(&mut self) {
+                kdebugln!(
+                    "memmap init: finished allocating, {} pages wasted",
+                    self.npages,
+                );
+            }
+        }
+
+        let mut bump = Bump {
+            next_ppn: sppn,
+            npages: npages,
+        };
+
+        MEMMAP.init(|root| {
+            unsafe {
+                let entry_ptr = root.as_mut_ptr().cast::<PhysPageNum>();
+                for i in 0..ENTRIES_PER_INDIRECT_LEVEL {
+                    entry_ptr.add(i).write(PhysPageNum::new(0));
+                }
+            }
+            let root = unsafe { root.assume_init_mut() } as *mut IndirectLevel;
+
+            sys_mem_zones().with_avail_zones(|zones| {
+                let section_mask = (NFRAMES_PER_SECTION as u64) - 1;
+                let section_stride = NFRAMES_PER_SECTION as u64;
+
+                for zone in zones {
+                    kdebugln!("initializing memmap for zone: {:?}", zone.range());
+                    let range = zone.range();
+                    if range.npages() == 0 {
+                        continue;
+                    }
+
+                    let end_ppn = range.end().get();
+                    let mut section_base = range.start().get() & !section_mask;
+
+                    while section_base < end_ppn {
+                        kdebugln!(
+                            "initializing memmap in section starting at ppn {:#x}",
+                            section_base
+                        );
+                        let section_base_ppn = PhysPageNum::new(section_base);
+                        let indices = indirect_indices_for(section_base_ppn);
+                        let mut cur_level = root;
+
+                        for i in (1..NINDIRECT_LEVELS).rev() {
+                            let idx = indices[i];
+
+                            let next_ppn = unsafe {
+                                let level = &mut *cur_level;
+                                let entry = &mut level.entries[idx];
+                                if entry.get() == 0 {
+                                    // do an alloc
+                                    *entry = bump.alloc(1);
+                                    // initialize the allocated page as an indirect level
+                                    unsafe {
+                                        (*entry)
+                                            .to_hhdm()
+                                            .to_virt_addr()
+                                            .as_ptr_mut::<IndirectLevel>()
+                                            .write(IndirectLevel::EMPTY);
+                                    }
+                                }
+                                *entry
+                            };
+
+                            cur_level = unsafe {
+                                next_ppn
+                                    .to_hhdm()
+                                    .to_virt_addr()
+                                    .as_ptr_mut::<IndirectLevel>()
+                            };
+                        }
+
+                        let section_idx = indices[0];
+                        unsafe {
+                            let level = &mut *cur_level;
+                            let entry = &mut level.entries[section_idx];
+                            if entry.get() == 0 {
+                                let section_ppn = bump.alloc(MEMSECTION_NPAGES);
+
+                                unsafe {
+                                    // we can't construct a memsection_ptr and write to it directly,
+                                    // since
+                                    // size_of::<MemSection>() is too large and will overflow the
+                                    // stack. That's why we write to each frame one by one.
+                                    //
+                                    // tbh, i kind of miss cpp's placement new here...
+
+                                    let frame_ptr =
+                                        section_ppn.to_hhdm().to_virt_addr().as_ptr_mut::<Frame>();
+                                    for i in 0..NFRAMES_PER_SECTION {
+                                        let frame_ptr = frame_ptr.add(i);
+                                        frame_ptr.write(Frame::EMPTY);
+                                        (&mut *frame_ptr).ppn = section_base_ppn + i as u64;
+                                    }
+                                }
+
+                                *entry = section_ppn;
+                            }
+                        }
+
+                        section_base += section_stride;
+                    }
+                }
+            });
+        });
+    }
+
+    /// Gets the underlying [Frame] corresponding to the given physical page
+    /// number.
+    ///
+    /// This function is intentionally designed not to return an
+    /// [Option]/[Result], since if a [None]/[Err] is returned, it indicates
+    /// a serious bug in the kernel, and we should just panic immediately.
+    ///
+    /// However, this function is marked as `unsafe`.
+    pub unsafe fn get_frame(ppn: PhysPageNum) -> &'static Frame {
+        let in_section_idx = ppn.get() & ((1 << FRAME_IN_SECTION_IDX_BITS) - 1);
+
+        let indirect_level_idx_indice = indirect_indices_for(ppn);
+
+        let section = {
+            let mut cur_ppn = MEMMAP.get().entries[indirect_level_idx_indice[NINDIRECT_LEVELS - 1]];
+            for i in (0..NINDIRECT_LEVELS - 1).rev() {
+                if cur_ppn.get() == 0 {
+                    panic!("Internal error: try to access an invalid frame");
+                }
+                cur_ppn = unsafe {
+                    NonNull::new_unchecked(
+                        cur_ppn
+                            .to_hhdm()
+                            .to_virt_addr()
+                            .as_ptr_mut::<IndirectLevel>(),
+                    )
+                    .as_ref()
+                }
+                .entries[indirect_level_idx_indice[i]];
+            }
+            if cur_ppn.get() == 0 {
+                panic!("Internal error: try to access an invalid frame");
+            }
+            unsafe {
+                NonNull::new_unchecked(cur_ppn.to_hhdm().to_virt_addr().as_ptr_mut::<MemSection>())
+                    .as_ref()
+            }
+        };
+
+        let frame_ptr = &section.frames[in_section_idx as usize] as *const Frame;
+
+        // SAFETY: after memmap is initialized, frame structures will remain valid for
+        // the whole system lifetime.
+
+        unsafe { &*frame_ptr }
+    }
+}
+pub use memmap::{get_frame, init};
+
+#[derive(Debug)]
+pub struct Frame {
+    /// The physical page number of this frame.
+    ///
+    /// What's this used for? tbh idk, but let's just store it here. maybe we'll
+    /// need it for debugging or something.
+    ppn: PhysPageNum,
+    rc: AtomicUsize,
+    // TODO: add flags for frame state
+}
+
+impl Frame {
+    const EMPTY: Self = Self {
+        ppn: PhysPageNum::new(0),
+        rc: AtomicUsize::new(0),
+    };
+
+    /// Internally, this indicates that the reference count of this frame is 0.
+    pub fn is_free(&self) -> bool {
+        self.rc.load(Ordering::Acquire) == 0
+    }
+
+    /// Internally, this indicates that the reference count of this frame is
+    /// greater than 0.
+    pub fn is_used(&self) -> bool {
+        !self.is_free()
+    }
+
+    /// Internally, this indicates that the reference count of this frame is
+    /// greater than 1.
+    pub fn is_shared(&self) -> bool {
+        self.rc.load(Ordering::Acquire) > 1
+    }
+
+    /// Increase the reference count of this frame by 1.
+    pub unsafe fn inc_ref(&self) {
+        self.rc.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Decrease the reference count of this frame by 1.
+    pub unsafe fn dec_ref(&self) {
+        if self.is_free() {
+            panic!("Internal error: trying to decrease reference count of a free frame");
+        }
+
+        self.rc.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    /// Returns the current reference count of this frame.
+    ///
+    /// This is mainly used for debugging and testing, and should not be used in
+    /// normal code.
+    pub fn rc(&self) -> usize {
+        self.rc.load(Ordering::Acquire)
+    }
+}

--- a/anemone-kernel/src/mm/frame/mod.rs
+++ b/anemone-kernel/src/mm/frame/mod.rs
@@ -12,6 +12,9 @@ mod buddy;
 mod managed;
 pub use managed::*;
 
+mod memmap;
+pub use memmap::{get_frame, init as memmap_init};
+
 static FRAME_ALLOCATOR: Lazy<LockedFrameAllocator<BuddyAllocator>> =
     Lazy::new(|| LockedFrameAllocator::new(BuddyAllocator::new()));
 
@@ -20,9 +23,9 @@ static FRAME_ALLOCATOR: Lazy<LockedFrameAllocator<BuddyAllocator>> =
 /// # Safety
 ///
 /// This function must be called exactly once during kernel initialization,
-/// after all memory zones have been added via [`add_mem_zone`]. The behavior is
-/// undefined if this function is called multiple times or if it is called
-/// before all memory zones have been added.
+/// after all memory zones have been added. The behavior is undefined if this
+/// function is called multiple times or if it is called before all memory zones
+/// have been added.
 pub unsafe fn pmm_init() {
     sys_mem_zones().with_avail_zones(|avail_zones| {
         for zone in avail_zones.iter() {
@@ -39,25 +42,88 @@ pub fn frame_allocator_stats() -> allocator::FrameAllocatorStats {
 }
 
 /// Allocates a contiguous range of physical pages.
-pub fn alloc_frames(npages: usize) -> Option<Folio> {
+pub fn alloc_frames(npages: usize) -> Option<OwnedFolio> {
+    assert_ne!(npages, 0, "Internal error: cannot allocate zero pages");
     FRAME_ALLOCATOR.alloc(npages)
 }
 
 /// Allocates a single physical page.
-pub fn alloc_frame() -> Option<Frame> {
+pub fn alloc_frame() -> Option<OwnedFrameHandle> {
     FRAME_ALLOCATOR.alloc_one()
 }
 
 /// Allocates a contiguous range of physical pages and zeroes them.
-pub fn alloc_frames_zeroed(npages: usize) -> Option<Folio> {
+pub fn alloc_frames_zeroed(npages: usize) -> Option<OwnedFolio> {
     let mut folio = alloc_frames(npages)?;
     folio.as_bytes_mut().fill(0);
     Some(folio)
 }
 
 /// Allocates a single physical page and zeroes it.
-pub fn alloc_frame_zeroed() -> Option<Frame> {
+pub fn alloc_frame_zeroed() -> Option<OwnedFrameHandle> {
     let mut frame = alloc_frame()?;
     frame.as_bytes_mut().fill(0);
     Some(frame)
+}
+
+#[kunit]
+fn alloc_frame_updates_stats_and_refcount() {
+    let before = frame_allocator_stats();
+
+    let frame = alloc_frame().expect("alloc_frame() should succeed during kunit");
+    let ppn = frame.leak();
+
+    assert_eq!(unsafe { get_frame(ppn) }.rc(), 1);
+
+    let during = frame_allocator_stats();
+    assert_eq!(during.used_pages(), before.used_pages() + 1);
+
+    let frame = unsafe { OwnedFrameHandle::from_ppn(ppn) };
+    drop(frame);
+
+    let after = frame_allocator_stats();
+    assert_eq!(after.used_pages(), before.used_pages());
+    assert_eq!(unsafe { get_frame(ppn) }.rc(), 0);
+}
+
+#[kunit]
+fn alloc_frames_updates_stats_and_refcount() {
+    const NPAGES: usize = 4;
+
+    let before = frame_allocator_stats();
+
+    let folio = alloc_frames(NPAGES).expect("alloc_frames() should succeed during kunit");
+    let range = folio.leak();
+
+    for ppn in range.iter() {
+        assert_eq!(unsafe { get_frame(ppn) }.rc(), 1);
+    }
+
+    let during = frame_allocator_stats();
+    assert_eq!(during.used_pages(), before.used_pages() + NPAGES as u64);
+
+    let folio = unsafe { OwnedFolio::from_range(range) };
+    drop(folio);
+
+    let after = frame_allocator_stats();
+    assert_eq!(after.used_pages(), before.used_pages());
+
+    for ppn in range.iter() {
+        assert_eq!(unsafe { get_frame(ppn) }.rc(), 0);
+    }
+}
+
+#[kunit]
+fn alloc_frame_zeroed_returns_zeroed_page() {
+    let frame = alloc_frame_zeroed().expect("alloc_frame_zeroed() should succeed during kunit");
+    assert!(frame.as_bytes().iter().all(|&byte| byte == 0));
+}
+
+#[kunit]
+fn alloc_frames_zeroed_returns_zeroed_folio() {
+    const NPAGES: usize = 2;
+
+    let folio =
+        alloc_frames_zeroed(NPAGES).expect("alloc_frames_zeroed() should succeed during kunit");
+    assert!(folio.as_bytes().iter().all(|&byte| byte == 0));
 }

--- a/anemone-kernel/src/mm/paging/hal.rs
+++ b/anemone-kernel/src/mm/paging/hal.rs
@@ -5,6 +5,11 @@ use crate::prelude::*;
 /// The architecture-specific traits and types for paging.
 pub trait PagingArchTrait: Sized {
     type PgDir: PgDirArch;
+
+    /// The maximum number of bits in the physical page number supported by this
+    /// architecture.
+    const MAX_PPN_BITS: usize;
+
     /// The minimum page size supported by the architecture, in bytes.
     const PAGE_SIZE_BYTES: usize;
     /// The number of bits in the page offset, i.e., the number of bits needed

--- a/anemone-kernel/src/mm/paging/mapper.rs
+++ b/anemone-kernel/src/mm/paging/mapper.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem::ManuallyDrop};
 
 use crate::prelude::*;
 
@@ -69,7 +69,6 @@ impl Mapper<'_> {
             mapper: &'a mut Mapper<'m>,
             mapping: Mapping,
             mapped_pages: usize,
-            is_committed: bool,
         }
 
         impl<'a, 'm> MapTransaction<'a, 'm> {
@@ -78,7 +77,6 @@ impl Mapper<'_> {
                     mapper,
                     mapping,
                     mapped_pages: 0,
-                    is_committed: false,
                 }
             }
 
@@ -100,22 +98,20 @@ impl Mapper<'_> {
                 Ok(())
             }
 
-            fn commit(mut self) {
-                self.is_committed = true;
+            fn commit(self) {
+                let _ = ManuallyDrop::new(self);
             }
         }
 
         impl Drop for MapTransaction<'_, '_> {
             fn drop(&mut self) {
-                if !self.is_committed {
-                    knoticeln!(
-                        "MapTransaction::Drop: transaction failed, rolling back the mapped pages"
-                    );
-                    // roll back the mapping of already mapped pages
-                    self.mapper.unmap(Unmapping {
-                        range: VirtPageRange::new(self.mapping.vpn, self.mapped_pages as u64),
-                    });
-                }
+                knoticeln!(
+                    "MapTransaction::Drop: transaction failed, rolling back the mapped pages"
+                );
+                // roll back the mapping of already mapped pages
+                self.mapper.unmap(Unmapping {
+                    range: VirtPageRange::new(self.mapping.vpn, self.mapped_pages as u64),
+                });
             }
         }
 
@@ -185,7 +181,7 @@ impl Mapper<'_> {
                         // deallocate the empty page table
                         let ppn = pte.ppn();
                         *pte = Pte::ZEROED;
-                        let _frame = Frame::from_ppn(ppn);
+                        let _frame = OwnedFrameHandle::from_ppn(ppn);
                     }
                     ControlFlow::<()>::Continue
                 },

--- a/anemone-kernel/src/mm/paging/pagetable.rs
+++ b/anemone-kernel/src/mm/paging/pagetable.rs
@@ -49,6 +49,6 @@ impl Drop for PageTable {
                 1 << (PagingArch::PAGE_LEVELS * PagingArch::PGDIR_IDX_BITS),
             ),
         });
-        let _frame = unsafe { Frame::from_ppn(self.root) };
+        let _frame = unsafe { OwnedFrameHandle::from_ppn(self.root) };
     }
 }

--- a/anemone-kernel/src/mm/zone.rs
+++ b/anemone-kernel/src/mm/zone.rs
@@ -39,6 +39,11 @@ bitflags! {
         ///
         /// TODO: This flag is in theory needless. We should use a RECLAIMABLE flag instead.
         const FDT = 0x0010;
+
+        /// Memory that is leaked (i.e., not managed by the physical memory manager).
+        ///
+        /// Often used during early boot.
+        const LEAKED = 0x0020;
     }
 }
 
@@ -188,6 +193,51 @@ impl SysMemZones {
             MemZone::Avail(avail_zone) => avail_mem_zones.push(avail_zone),
             MemZone::Rsv(rsv_zone) => rsv_mem_zones.push(rsv_zone),
         }
+    }
+
+    /// Leaks a contiguous range of physical pages from the available memory
+    /// zones, making it reserved thus not managed by the physical memory
+    /// manager.
+    pub fn leak(&self, npages: usize) -> Option<PhysPageNum> {
+        let mut mem_zones = self.mem_zones.lock_irqsave();
+        let mut avail_mem_zones = self.avail_mem_zones.lock_irqsave();
+        let mut rsv_mem_zones = self.rsv_mem_zones.lock_irqsave();
+
+        let mut allocated_sppn = None;
+
+        for avail_zone in avail_mem_zones.iter_mut() {
+            if avail_zone.npages >= npages as u64 {
+                allocated_sppn = Some(avail_zone.start_ppn);
+                avail_zone.start_ppn += npages as u64;
+                avail_zone.npages -= npages as u64;
+                kdebugln!("SysMemZones::leak: leaking {} pages", npages);
+                break;
+            }
+        }
+
+        rsv_mem_zones.push(RsvMemZone::new(
+            allocated_sppn.unwrap(),
+            npages as u64,
+            RsvMemFlags::LEAKED,
+        ));
+
+        // sync with mem_zones
+        for mem_zone in mem_zones.iter_mut() {
+            if let MemZone::Avail(mem_zone) = mem_zone {
+                if mem_zone.start_ppn == allocated_sppn.unwrap() {
+                    mem_zone.start_ppn += npages as u64;
+                    mem_zone.npages -= npages as u64;
+                    break;
+                }
+            }
+        }
+        mem_zones.push(MemZone::Rsv(RsvMemZone::new(
+            allocated_sppn.unwrap(),
+            npages as u64,
+            RsvMemFlags::LEAKED,
+        )));
+
+        allocated_sppn
     }
 }
 

--- a/anemone-kernel/src/sync/mono.rs
+++ b/anemone-kernel/src/sync/mono.rs
@@ -1,5 +1,6 @@
 use core::{
     cell::UnsafeCell,
+    mem::MaybeUninit,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -20,7 +21,7 @@ use core::{
 ///
 /// 1. **Sequential Access**: The core requirement for using `MonoFlow`.
 /// 2. **Non-Reentrancy**: The requirement from Rust's aliasing rules. Currently
-///    enforced in debug builds.
+///    enforced in dev builds.
 #[derive(Debug)]
 pub struct MonoFlow<T> {
     data: UnsafeCell<T>,
@@ -99,14 +100,14 @@ impl<T> MonoFlow<T> {
 /// See [`MonoFlow`] for details on the synchronization model.
 ///
 /// **In effect, since [`MonoOnce`] does not provide mutable access to the inner
-/// data, it can be simultaneously accessed by multiple control flows**
+/// data, it can be simultaneously accessed by multiple control flows.**
 ///
 /// **The 'Mono' in the name stands for the fact that the action to initialize
 /// the inner data is guaranteed to be performed only once and before any access
 /// to the inner data.**
 #[derive(Debug)]
 pub struct MonoOnce<T> {
-    data: UnsafeCell<Option<T>>,
+    data: UnsafeCell<MaybeUninit<T>>,
     #[cfg(debug_assertions)]
     initialized: AtomicBool,
 }
@@ -116,7 +117,7 @@ unsafe impl<T: Sync> Sync for MonoOnce<T> {}
 impl<T> MonoOnce<T> {
     pub const unsafe fn new() -> Self {
         MonoOnce {
-            data: UnsafeCell::new(None),
+            data: UnsafeCell::new(MaybeUninit::uninit()),
             #[cfg(debug_assertions)]
             initialized: AtomicBool::new(false),
         }
@@ -124,14 +125,13 @@ impl<T> MonoOnce<T> {
 
     pub fn init<F>(&self, init: F)
     where
-        F: FnOnce() -> T,
+        F: FnOnce(&mut MaybeUninit<T>),
         T: Sized,
     {
         #[cfg(debug_assertions)]
         {
             if !self.initialized.load(Ordering::Acquire) {
-                let value = init();
-                unsafe { *self.data.get() = Some(value) };
+                init(unsafe { &mut *self.data.get() });
                 self.initialized.store(true, Ordering::Release);
             } else {
                 panic!("MonoOnce: already initialized");
@@ -140,17 +140,11 @@ impl<T> MonoOnce<T> {
 
         #[cfg(not(debug_assertions))]
         {
-            let value = init();
-            unsafe { *self.data.get() = Some(value) };
+            init(unsafe { &mut *self.data.get() });
         }
     }
 
     pub fn get(&self) -> &T {
-        unsafe {
-            match &*self.data.get() {
-                Some(value) => value,
-                None => panic!("MonoOnce: not initialized"),
-            }
-        }
+        unsafe { (&*self.data.get()).assume_init_ref() }
     }
 }

--- a/conf/platforms/example.toml
+++ b/conf/platforms/example.toml
@@ -28,6 +28,8 @@ kernel_la_base = 0x80200000
 kernel_va_base = 0xffffffff80200000
 # Maximum number of CPUs supported by this platform
 max_cpus = 4
+# Page frame section size as a power of 2 in megabytes.
+frame_section_shift_mb = 7
 
 # QEMU configuration
 # This section defines how to run the target platform in QEMU,

--- a/conf/platforms/qemu-virt-rv64.toml
+++ b/conf/platforms/qemu-virt-rv64.toml
@@ -10,6 +10,8 @@ max_phys_ram_size = 0x80000000      # 2GB
 kernel_la_base = 0x80200000
 kernel_va_base = 0xffffffff80200000
 max_cpus = 4
+frame_section_shift_mb = 7
+
 
 [qemu]
 qemu = "qemu-system-riscv64"

--- a/scripts/xtask/src/config/platform.rs
+++ b/scripts/xtask/src/config/platform.rs
@@ -57,6 +57,7 @@ pub struct Constants {
     pub kernel_la_base: u64,
     pub kernel_va_base: u64,
     pub max_cpus: usize,
+    pub frame_section_shift_mb: usize,
 }
 
 #[derive(Deserialize, Debug)]
@@ -97,6 +98,8 @@ pub const KERNEL_LA_BASE: u64 = {:#x};
 pub const KERNEL_VA_BASE: u64 = {:#x};
 /// Maximum number of CPUs supported
 pub const MAX_CPUS: usize = {};
+/// Frame section size shift in megabytes
+pub const FRAME_SECTION_SHIFT_MB: usize = {};
 
         "#,
             self.constants.phys_ram_start,
@@ -104,6 +107,7 @@ pub const MAX_CPUS: usize = {};
             self.constants.kernel_la_base,
             self.constants.kernel_va_base,
             self.constants.max_cpus,
+            self.constants.frame_section_shift_mb,
         )
     }
 }


### PR DESCRIPTION
This PR mainly does:
- frame metadata tracking based on sparse memory model,
- better RAII wrapper around raw frames, and
- some minor changes to support the above two features. (e.g. `MonoOnce` type now constructs value via pointer, thus avoiding stack overuse in some cases)

Closes #24 