### PR TITLE
Modified scripts to support compilation in macOS

### DIFF
--- a/scripts/xtask/src/config/build.rs
+++ b/scripts/xtask/src/config/build.rs
@@ -4,14 +4,12 @@ use crate::config::platform::*;
 impl TargetTriple {
     pub fn objdump(&self) -> &'static str {
         match self {
-            Self::RiscV64UnknownAnemoneElf =>{ 
+            Self::RiscV64UnknownAnemoneElf => {
                 if cfg!(target_os = "linux") {
                     "riscv64-unknown-elf-objdump"
-                }
-                else if cfg!(target_os = "macos") {
+                } else if cfg!(target_os = "macos") {
                     "riscv64-elf-objdump"
-                }
-                else {
+                } else {
                     unimplemented!("Objdump for target triple {:?} is not implemented on this platform", self)
                 }
             },


### PR DESCRIPTION
Add logic like the following to select the platform-specific binutils names.
```Rust
if cfg!(target_os = "linux") {
    ...
}
else if cfg!(target_os = "macos") {
    ...
}
```